### PR TITLE
Fix out-of-bound access in iterate_each helper

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -80,7 +80,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 	size_t offset = 0;
 	size_t i = 0;
 
-	for (i = 0; i < nr_items; i++) {
+	for (i = 0; (i + offset) < nr_items; i++) {
 		const cbor_item_t *item = &items[i+offset];
 
 		if (item->type == CBOR_ITEM_MAP


### PR DESCRIPTION
This pull request includes an important change to the `src/helper.c` file. The modification ensures that the loop condition in the `iterate_each` function correctly accounts for the offset when iterating over items.

* [`src/helper.c`](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeL83-R83): Modified the loop condition in the `iterate_each` function to `(i + offset) < nr_items` to ensure proper iteration over items.