### PR TITLE
feat(parser): add cbor_count_items for dry-run item counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,15 @@ Each `cbor_item_t` represents one parsed CBOR node (container and leaf both
 count as one item). `cbor_get_item_size()` unit depends on the item type:
 
 * Integer / float / simple value: encoded payload size in bytes
-* Byte/text string: string length in bytes
-* Array: number of child items
-* Map: number of key-value pairs
+* Byte/text string (definite-length): string length in bytes
+* Array (definite-length): number of child items
+* Map (definite-length): number of key-value pairs
+
+For **indefinite-length** strings, arrays, and maps, `cbor_get_item_size()`
+returns the raw CBOR length field, which is the sentinel
+`(size_t)CBOR_INDEFINITE_VALUE`. In that case, the number of child items / key-
+value pairs is not known up front; iterate until the CBOR BREAK marker is
+encountered instead of using `cbor_get_item_size()` as a count.
 
 Example (`0xA2 0x61 0x61 0x01 0x61 0x62 0x02`, equivalent to
 `{"a": 1, "b": 2}`):
@@ -188,6 +194,13 @@ or from file:
 
 ```bash
 python3 tools/cbor_item_count.py --file ./message.cbor
+```
+
+If your build overrides `CBOR_RECURSION_MAX_LEVEL`, pass the same depth to the
+script so it matches parser behavior:
+
+```bash
+python3 tools/cbor_item_count.py --file ./message.cbor --max-depth 16
 ```
 
 The script prints parser-compatible status (`CBOR_SUCCESS`, `CBOR_BREAK`,

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ buffer:
 size_t needed_items = 0;
 cbor_error_t err = cbor_count_items(cbor_message, cbor_message_len,
 		&needed_items);
-if (err == CBOR_SUCCESS || err == CBOR_BREAK) {
+if (err == CBOR_SUCCESS) {
 	/* allocate items[needed_items + margin] */
 }
 ```

--- a/README.md
+++ b/README.md
@@ -107,12 +107,91 @@ size_t n;
 cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
 cbor_parse(&reader, cbor_message, cbor_message_len, &n);
 
-for (i = 0; i < n; i++) {
+for (size_t i = 0; i < n; i++) {
 	printf("item: %s, size: %zu\n",
 			cbor_stringify_item(&items[i]),
-			cbor_get_item_size(&items[i]);
+			cbor_get_item_size(&items[i]));
 }
 ```
+
+`MAX_ITEMS` is a capacity in **number of parsed items**, not bytes. The memory
+footprint of this array is:
+
+```c
+size_t item_buffer_bytes = MAX_ITEMS * sizeof(cbor_item_t);
+```
+
+`sizeof(cbor_item_t)` is platform dependent (e.g. typically 12 bytes on many
+32-bit MCUs, and often 24 bytes on 64-bit hosts).
+
+Each `cbor_item_t` represents one parsed CBOR node (container and leaf both
+count as one item). `cbor_get_item_size()` unit depends on the item type:
+
+* Integer / float / simple value: encoded payload size in bytes
+* Byte/text string: string length in bytes
+* Array: number of child items
+* Map: number of key-value pairs
+
+Example (`0xA2 0x61 0x61 0x01 0x61 0x62 0x02`, equivalent to
+`{"a": 1, "b": 2}`):
+
+* 1 map item
+* 2 key items (`"a"`, `"b"`)
+* 2 value items (`1`, `2`)
+* total parsed item count (`n`) = 5
+
+### Sizing `MAX_ITEMS` (pre-estimation)
+
+Use `cbor_count_items()` for dry-run counting without allocating `cbor_item_t`
+buffer:
+
+```c
+size_t needed_items = 0;
+cbor_error_t err = cbor_count_items(cbor_message, cbor_message_len,
+		&needed_items);
+if (err == CBOR_SUCCESS || err == CBOR_BREAK) {
+	/* allocate items[needed_items + margin] */
+}
+```
+
+In practice, use one of the following:
+
+1. Reserve a conservative static capacity based on your schema, or
+2. Call `cbor_count_items()` first, then set production `MAX_ITEMS` with margin.
+
+### Error when item capacity is not enough
+
+If `items[]` is too small to hold all parsed nodes, `cbor_parse()` returns
+`CBOR_OVERRUN` (stringified as `"out of memory"`).
+
+```c
+cbor_error_t err = cbor_parse(&reader, msg, msglen, &n);
+if (err == CBOR_OVERRUN) {
+	/* items[] capacity is insufficient: increase maxitems */
+}
+```
+
+In this case, `n` contains only the number of items actually stored before the
+overrun.
+
+## Tools
+
+### Item counter script
+
+You can estimate item count from CBOR bytes with:
+
+```bash
+python3 tools/cbor_item_count.py --hex "A2 61 61 01 61 62 02"
+```
+
+or from file:
+
+```bash
+python3 tools/cbor_item_count.py --file ./message.cbor
+```
+
+The script prints parser-compatible status (`CBOR_SUCCESS`, `CBOR_BREAK`,
+`CBOR_ILLEGAL`, etc.) and counted item number.
 
 ### Decoder
 

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -137,8 +137,9 @@ size_t cbor_get_item_size(cbor_item_t const *item);
  *
  * @param[in] additional_info low-order 5-bit additional information
  *
- * @return number of following bytes, or sentinel values defined by
- *         `CBOR_INDEFINITE_VALUE`/`CBOR_RESERVED_VALUE`
+ * @return number of following bytes, or sentinel values returned as
+ *         `(uint8_t)CBOR_INDEFINITE_VALUE` / `(uint8_t)CBOR_RESERVED_VALUE`
+ *         (currently `0xFF` / `0xFE`)
  */
 uint8_t cbor_get_following_bytes(uint8_t additional_info);
 

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #if !defined(CBOR_RECURSION_MAX_LEVEL)
@@ -166,6 +167,19 @@ size_t cbor_copy(uint8_t *dst, uint8_t const *src, size_t len);
  * @return bytes copied
  */
 size_t cbor_copy_be(uint8_t *dst, uint8_t const *src, size_t len);
+
+/**
+ * Check if a parsed item is a CBOR BREAK token.
+ *
+ * @param[in] item parsed CBOR item
+ *
+ * @return true if @p item is BREAK token, otherwise false
+ */
+static inline bool cbor_item_is_break(cbor_item_t const *item)
+{
+	return item->type == CBOR_ITEM_FLOAT &&
+		item->size == (size_t)(uint8_t)CBOR_INDEFINITE_VALUE;
+}
 
 #if defined(__cplusplus)
 }

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -76,16 +76,94 @@ typedef struct {
  * @param[in] maxitems the maximum number of items to be stored in @p items
  */
 void cbor_reader_init(cbor_reader_t *reader, cbor_item_t *items, size_t maxitems);
+
+/**
+ * Initialize the writer for CBOR encoding.
+ *
+ * @param[in,out] writer writer context
+ * @param[out] buf output buffer for encoded bytes
+ * @param[in] bufsize size of @p buf in bytes
+ */
 void cbor_writer_init(cbor_writer_t *writer, void *buf, size_t bufsize);
+
+/**
+ * Get the number of bytes encoded into the writer buffer.
+ *
+ * @param[in] writer writer context
+ *
+ * @return encoded byte length
+ */
 size_t cbor_writer_len(cbor_writer_t const *writer);
+
+/**
+ * Get the pointer to the encoded writer buffer.
+ *
+ * @param[in] writer writer context
+ *
+ * @return pointer to the encoded bytes
+ */
 uint8_t const *cbor_writer_get_encoded(cbor_writer_t const *writer);
 
+/**
+ * Get the parsed CBOR item type.
+ *
+ * @param[in] item parsed CBOR item
+ *
+ * @return item data type
+ */
 cbor_item_data_t cbor_get_item_type(cbor_item_t const *item);
+
+/**
+ * Get the parsed CBOR size field of an item.
+ *
+ * Semantics depend on the item type and encoding form:
+ * - Integer / float / simple value: encoded payload size in bytes
+ * - Byte/text string (definite-length): string length in bytes
+ * - Array (definite-length): number of child items
+ * - Map (definite-length): number of key-value pairs
+ *
+ * For indefinite-length string/array/map, this returns
+ * `(size_t)CBOR_INDEFINITE_VALUE`, which means the size is unknown up front and
+ * should not be treated as a child-count.
+ *
+ * @param[in] item parsed CBOR item
+ *
+ * @return parsed CBOR size field for @p item
+ */
 size_t cbor_get_item_size(cbor_item_t const *item);
 
+/**
+ * Convert additional-info value to the number of following bytes.
+ *
+ * @param[in] additional_info low-order 5-bit additional information
+ *
+ * @return number of following bytes, or sentinel values defined by
+ *         `CBOR_INDEFINITE_VALUE`/`CBOR_RESERVED_VALUE`
+ */
 uint8_t cbor_get_following_bytes(uint8_t additional_info);
 
+/**
+ * Copy bytes from CBOR payload into host-endian order.
+ *
+ * Uses the library endianness configuration (`CBOR_BIG_ENDIAN`).
+ *
+ * @param[out] dst destination buffer
+ * @param[in] src source buffer
+ * @param[in] len number of bytes to copy
+ *
+ * @return bytes copied
+ */
 size_t cbor_copy(uint8_t *dst, uint8_t const *src, size_t len);
+
+/**
+ * Copy bytes as big-endian order.
+ *
+ * @param[out] dst destination buffer
+ * @param[in] src source buffer
+ * @param[in] len number of bytes to copy
+ *
+ * @return bytes copied
+ */
 size_t cbor_copy_be(uint8_t *dst, uint8_t const *src, size_t len);
 
 #if defined(__cplusplus)

--- a/include/cbor/parser.h
+++ b/include/cbor/parser.h
@@ -26,6 +26,18 @@ extern "C" {
 cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
 		size_t *nitems_parsed);
 
+/**
+ * Count CBOR items from encoded CBOR message without storing item metadata.
+ *
+ * @param[in] msg CBOR encoded message
+ * @param[in] msgsize the @p msg size in bytes
+ * @param[out] nitems_counted the number of items counted gets stored if not null
+ *
+ * @return a code of @ref cbor_error_t
+ */
+cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
+		size_t *nitems_counted);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/cbor/parser.h
+++ b/include/cbor/parser.h
@@ -31,7 +31,10 @@ cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
  *
  * @param[in] msg CBOR encoded message
  * @param[in] msgsize the @p msg size in bytes
- * @param[out] nitems_counted the number of items counted gets stored if not null
+ * @param[out] nitems_counted the number of items counted gets stored
+ *             if not null. This value is written even when the return code
+ *             is an error, and then indicates the number of items counted
+ *             before the parser stopped.
  *
  * @return a code of @ref cbor_error_t
  */

--- a/include/cbor/parser.h
+++ b/include/cbor/parser.h
@@ -36,7 +36,9 @@ cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
  *             is an error, and then indicates the number of items counted
  *             before the parser stopped.
  *
- * @return a code of @ref cbor_error_t
+ * @return a code of @ref cbor_error_t. Unlike @ref cbor_parse(),
+ *         well-formed indefinite-length items do not cause this function to
+ *         return @ref CBOR_BREAK; they are reported as @ref CBOR_SUCCESS.
  */
 cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
 		size_t *nitems_counted);

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -5,7 +5,6 @@
  */
 
 #include "cbor/decoder.h"
-#include <stdbool.h>
 #include <string.h>
 
 #if !defined(MIN)
@@ -49,11 +48,6 @@ static uint8_t get_simple_value(uint8_t val)
 	default:
 		return val;
 	}
-}
-
-static bool is_break(cbor_item_t const *item)
-{
-	return item->type == CBOR_ITEM_FLOAT && item->size == 0xff;
 }
 
 static cbor_error_t decode_unsigned_integer(cbor_item_t const *item,
@@ -158,7 +152,7 @@ void const *cbor_decode_pointer(cbor_reader_t const *reader,
 cbor_error_t cbor_decode(cbor_reader_t const *reader, cbor_item_t const *item,
 		void *buf, size_t bufsize)
 {
-	if (is_break(item)) {
+	if (cbor_item_is_break(item)) {
 		return CBOR_BREAK;
 	}
 	if (item->size > bufsize || bufsize == 0 || buf == NULL) {

--- a/src/helper.c
+++ b/src/helper.c
@@ -142,7 +142,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			break;
 		}
 
-		if (item->type == CBOR_ITEM_FLOAT && item->size == 0xffu) {
+		if (cbor_item_is_break(item)) {
 			/* account for the BREAK token in the consumed count */
 			if (parent && parent->size == (size_t)
 					CBOR_INDEFINITE_VALUE) {

--- a/src/helper.c
+++ b/src/helper.c
@@ -39,7 +39,7 @@ static const struct cbor_parser *get_parser(const struct parser_ctx *ctx,
 }
 
 static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
-		    const cbor_item_t *parent, void *arg)
+		const cbor_item_t *parent, void *arg)
 {
 	struct parser_ctx *ctx = (struct parser_ctx *)arg;
 	const void *strkey = NULL;
@@ -51,17 +51,17 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 			return;
 		}
 
-		if ((item-1)->type == CBOR_ITEM_INTEGER) {
-			cbor_decode(reader, item-1, &intkey, sizeof(intkey));
+		if ((item - 1)->type == CBOR_ITEM_INTEGER) {
+			cbor_decode(reader, item - 1, &intkey, sizeof(intkey));
 		} else {
-			strkey = cbor_decode_pointer(reader, item-1);
-			strkey_len = (item-1)->size;
+			strkey = cbor_decode_pointer(reader, item - 1);
+			strkey_len = (item - 1)->size;
 		}
 	}
 
 	if (strkey || intkey != -1) {
-		const struct cbor_parser *parser = get_parser(ctx,
-				intkey, strkey, strkey_len);
+		const struct cbor_parser *parser =
+			get_parser(ctx, intkey, strkey, strkey_len);
 
 		if (parser && parser->run) {
 			parser->run(reader, parser, item, ctx->arg);
@@ -70,32 +70,45 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 }
 
 static size_t iterate_each(const cbor_reader_t *reader,
-		    const cbor_item_t *items, size_t nr_items,
-		    const cbor_item_t *parent,
-		    void (*callback_each)(const cbor_reader_t *reader,
-			    const cbor_item_t *item, const cbor_item_t *parent,
-			    void *arg),
-		    void *arg)
+		const cbor_item_t *items, size_t nr_items, size_t max_nodes,
+		const cbor_item_t *parent, void (*callback_each)
+			(const cbor_reader_t *reader, const cbor_item_t *item,
+				   const cbor_item_t *parent, void *arg),
+		void *arg)
 {
 	size_t offset = 0;
 	size_t i = 0;
 
 	for (i = 0; i < nr_items; i++) {
-		if (!parent && (i + offset) >= nr_items) {
+		if ((i + offset) >= max_nodes) {
 			break;
 		}
-		const cbor_item_t *item = &items[i+offset];
+		const cbor_item_t *item = &items[i + offset];
 
-		if (item->type == CBOR_ITEM_MAP
-				|| item->type == CBOR_ITEM_ARRAY) {
-			size_t len = item->type == CBOR_ITEM_MAP?
-					item->size*2 : item->size;
-			offset += iterate_each(reader, item+1, len, item,
+		if (item->type == CBOR_ITEM_MAP ||
+				item->type == CBOR_ITEM_ARRAY) {
+			size_t len = item->size;
+
+			if (item->size == (size_t)CBOR_INDEFINITE_VALUE) {
+				len = max_nodes - (i + offset + 1);
+			} else if (item->type == CBOR_ITEM_MAP) {
+				if (item->size > SIZE_MAX / 2) {
+					break;
+				}
+				len *= 2;
+			}
+
+			offset += iterate_each(reader, item + 1, len,
+					max_nodes - (i + offset + 1), item,
 					callback_each, arg);
 			continue;
 		}
 
 		if (cbor_decode(reader, item, 0, 0) == CBOR_BREAK) {
+			if (parent && parent->size == (size_t)
+					CBOR_INDEFINITE_VALUE) {
+				i++;
+			}
 			break;
 		}
 
@@ -105,9 +118,8 @@ static size_t iterate_each(const cbor_reader_t *reader,
 	return i + offset;
 }
 
-bool cbor_unmarshal(cbor_reader_t *reader,
-		const struct cbor_parser *parsers, size_t nr_parsers,
-		const void *msg, size_t msglen, void *arg)
+bool cbor_unmarshal(cbor_reader_t *reader, const struct cbor_parser *parsers,
+		size_t nr_parsers, const void *msg, size_t msglen, void *arg)
 {
 	size_t n;
 	cbor_error_t err = cbor_parse(reader, msg, msglen, &n);
@@ -122,20 +134,19 @@ bool cbor_unmarshal(cbor_reader_t *reader,
 		.arg = arg,
 	};
 
-	iterate_each(reader, reader->items, n, 0, parse_item, &ctx);
+	iterate_each(reader, reader->items, n, n, 0, parse_item, &ctx);
 
 	return true;
 }
 
-size_t cbor_iterate(const cbor_reader_t *reader,
-		    const cbor_item_t *parent,
-		    void (*callback_each)(const cbor_reader_t *reader,
-			    const cbor_item_t *item, const cbor_item_t *parent,
-			    void *arg),
-		    void *arg)
+size_t cbor_iterate(const cbor_reader_t *reader, const cbor_item_t *parent,
+		void (*callback_each)(const cbor_reader_t *reader,
+				const cbor_item_t *item,
+				const cbor_item_t *parent, void *arg),
+		void *arg)
 {
 	return iterate_each(reader, reader->items, reader->itemidx,
-			parent, callback_each, arg);
+			reader->itemidx, parent, callback_each, arg);
 }
 
 const char *cbor_stringify_error(cbor_error_t err)

--- a/src/helper.c
+++ b/src/helper.c
@@ -69,11 +69,50 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 	}
 }
 
+static bool is_recursive_iteration_needed(const cbor_item_t *item,
+		size_t remaining_nodes, size_t *len,
+		bool *call_callback_before_recurse, bool *stop_iteration)
+{
+	*call_callback_before_recurse = false;
+	*stop_iteration = false;
+
+	if (item->type == CBOR_ITEM_STRING &&
+			item->size == (size_t)CBOR_INDEFINITE_VALUE) {
+		*len = remaining_nodes;
+		*call_callback_before_recurse = true;
+		return true;
+	}
+
+	if (item->type != CBOR_ITEM_MAP && item->type != CBOR_ITEM_ARRAY) {
+		return false;
+	}
+
+	if (item->size == (size_t)CBOR_INDEFINITE_VALUE) {
+		*len = remaining_nodes;
+		return true;
+	}
+
+	if (item->type == CBOR_ITEM_MAP) {
+		if (item->size > SIZE_MAX / 2) {
+			*stop_iteration = true;
+			return false;
+		}
+
+		*len = item->size * 2;
+		return true;
+	}
+
+	*len = item->size;
+
+	return true;
+}
+
 static size_t iterate_each(const cbor_reader_t *reader,
 		const cbor_item_t *items, size_t nr_items, size_t max_nodes,
-		const cbor_item_t *parent, void (*callback_each)
-			(const cbor_reader_t *reader, const cbor_item_t *item,
-				   const cbor_item_t *parent, void *arg),
+		const cbor_item_t *parent,
+		void (*callback_each)(const cbor_reader_t *reader,
+				const cbor_item_t *item,
+				const cbor_item_t *parent, void *arg),
 		void *arg)
 {
 	size_t offset = 0;
@@ -84,24 +123,26 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			break;
 		}
 		const cbor_item_t *item = &items[i + offset];
+		size_t remaining_nodes = max_nodes - (i + offset + 1);
+		size_t len;
+		bool call_callback_before_recurse;
+		bool stop_iteration;
 
-		if (item->type == CBOR_ITEM_MAP ||
-				item->type == CBOR_ITEM_ARRAY) {
-			size_t len = item->size;
-
-			if (item->size == (size_t)CBOR_INDEFINITE_VALUE) {
-				len = max_nodes - (i + offset + 1);
-			} else if (item->type == CBOR_ITEM_MAP) {
-				if (item->size > SIZE_MAX / 2) {
-					break;
-				}
-				len *= 2;
+		if (is_recursive_iteration_needed(item, remaining_nodes, &len,
+				&call_callback_before_recurse,
+				&stop_iteration)) {
+			if (call_callback_before_recurse) {
+				(*callback_each)(reader, item, parent, arg);
 			}
 
 			offset += iterate_each(reader, item + 1, len,
-					max_nodes - (i + offset + 1), item,
+					remaining_nodes, item,
 					callback_each, arg);
 			continue;
+		}
+
+		if (stop_iteration) {
+			break;
 		}
 
 		if (cbor_decode(reader, item, 0, 0) == CBOR_BREAK) {

--- a/src/helper.c
+++ b/src/helper.c
@@ -142,7 +142,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			break;
 		}
 
-		if (cbor_decode(reader, item, 0, 0) == CBOR_BREAK) {
+		if (item->type == CBOR_ITEM_FLOAT && item->size == 0xffu) {
 			/* account for the BREAK token in the consumed count */
 			if (parent && parent->size == (size_t)
 					CBOR_INDEFINITE_VALUE) {

--- a/src/helper.c
+++ b/src/helper.c
@@ -69,42 +69,42 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 	}
 }
 
-static bool is_recursive_iteration_needed(const cbor_item_t *item,
-		size_t remaining_nodes, size_t *len,
-		bool *call_callback_before_recurse, bool *stop_iteration)
-{
-	*call_callback_before_recurse = false;
-	*stop_iteration = false;
+typedef enum {
+	ITER_LEAF,                   /* not a container; decode and callback */
+	ITER_RECURSE,                /* container; recurse into children */
+	ITER_RECURSE_CALLBACK_FIRST, /* indefinite string; callback then recurse */
+	ITER_STOP,                   /* MAP size overflow; abort iteration */
+} iter_action_t;
 
+static iter_action_t get_iter_action(const cbor_item_t *item,
+		size_t remaining_nodes, size_t *len)
+{
 	if (item->type == CBOR_ITEM_STRING &&
 			item->size == (size_t)CBOR_INDEFINITE_VALUE) {
 		*len = remaining_nodes;
-		*call_callback_before_recurse = true;
-		return true;
+		return ITER_RECURSE_CALLBACK_FIRST;
 	}
 
 	if (item->type != CBOR_ITEM_MAP && item->type != CBOR_ITEM_ARRAY) {
-		return false;
+		return ITER_LEAF;
 	}
 
 	if (item->size == (size_t)CBOR_INDEFINITE_VALUE) {
 		*len = remaining_nodes;
-		return true;
+		return ITER_RECURSE;
 	}
 
 	if (item->type == CBOR_ITEM_MAP) {
 		if (item->size > SIZE_MAX / 2) {
-			*stop_iteration = true;
-			return false;
+			return ITER_STOP;
 		}
 
 		*len = item->size * 2;
-		return true;
+		return ITER_RECURSE;
 	}
 
 	*len = item->size;
-
-	return true;
+	return ITER_RECURSE;
 }
 
 static size_t iterate_each(const cbor_reader_t *reader,
@@ -115,37 +115,35 @@ static size_t iterate_each(const cbor_reader_t *reader,
 				const cbor_item_t *parent, void *arg),
 		void *arg)
 {
-	size_t offset = 0;
+	size_t extra = 0;
 	size_t i = 0;
 
 	for (i = 0; i < nr_items; i++) {
-		if ((i + offset) >= max_nodes) {
+		if ((i + extra) >= max_nodes) {
 			break;
 		}
-		const cbor_item_t *item = &items[i + offset];
-		size_t remaining_nodes = max_nodes - (i + offset + 1);
+		const cbor_item_t *item = &items[i + extra];
+		size_t remaining_nodes = max_nodes - (i + extra + 1);
 		size_t len;
-		bool call_callback_before_recurse;
-		bool stop_iteration;
 
-		if (is_recursive_iteration_needed(item, remaining_nodes, &len,
-				&call_callback_before_recurse,
-				&stop_iteration)) {
-			if (call_callback_before_recurse) {
-				(*callback_each)(reader, item, parent, arg);
-			}
-
-			offset += iterate_each(reader, item + 1, len,
+		switch (get_iter_action(item, remaining_nodes, &len)) {
+		case ITER_RECURSE_CALLBACK_FIRST:
+			(*callback_each)(reader, item, parent, arg);
+			/* fall through */
+		case ITER_RECURSE:
+			extra += iterate_each(reader, item + 1, len,
 					remaining_nodes, item,
 					callback_each, arg);
 			continue;
-		}
-
-		if (stop_iteration) {
+		case ITER_STOP:
+			return i + extra;
+		case ITER_LEAF:
+		default:
 			break;
 		}
 
 		if (cbor_decode(reader, item, 0, 0) == CBOR_BREAK) {
+			/* account for the BREAK token in the consumed count */
 			if (parent && parent->size == (size_t)
 					CBOR_INDEFINITE_VALUE) {
 				i++;
@@ -156,7 +154,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 		(*callback_each)(reader, item, parent, arg);
 	}
 
-	return i + offset;
+	return i + extra;
 }
 
 bool cbor_unmarshal(cbor_reader_t *reader, const struct cbor_parser *parsers,

--- a/src/parser.c
+++ b/src/parser.c
@@ -85,15 +85,17 @@ static size_t go_get_item_length(struct parser_context *ctx)
 	return (size_t)len;
 }
 
-static cbor_error_t parse(struct parser_context *ctx, size_t maxitems)
+static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
+		size_t *nitems_parsed)
 {
 	cbor_error_t err = CBOR_SUCCESS;
+	size_t i;
 
 	if (++ctx->recursion_depth > CBOR_RECURSION_MAX_LEVEL) {
 		return CBOR_EXCESSIVE;
 	}
 
-	for (size_t i = 0; i < maxitems &&
+	for (i = 0; i < maxitems &&
 			ctx->reader->itemidx < ctx->reader->maxitems &&
 			ctx->reader->msgidx < ctx->reader->msgsize; i++) {
 		uint8_t val = ctx->reader->msg[ctx->reader->msgidx];
@@ -122,8 +124,11 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems)
 	}
 
 	ctx->recursion_depth--;
+	if (nitems_parsed != NULL) {
+		*nitems_parsed = i;
+	}
 
-	assert(ctx->msgidx <= ctx->msgsize);
+	assert(ctx->reader->msgidx <= ctx->reader->msgsize);
 
 	return err;
 }
@@ -165,7 +170,7 @@ static cbor_error_t do_string(struct parser_context *ctx)
 
 	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
 		ctx->reader->itemidx++;
-		err = parse(ctx, (size_t)CBOR_INDEFINITE_VALUE);
+		err = parse(ctx, (size_t)CBOR_INDEFINITE_VALUE, NULL);
 		if (err != CBOR_SUCCESS) {
 			return err;
 		} else if (ctx->reader->itemidx >= ctx->reader->maxitems) {
@@ -187,7 +192,6 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 {
 	size_t len = go_get_item_length(ctx);
 	size_t expected_items = len;
-	size_t nitems_before = ctx->reader->itemidx;
 	cbor_error_t err;
 
 	set_item(ctx, (cbor_item_data_t)(ctx->major_type - 1),
@@ -201,20 +205,13 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	}
 
 	ctx->reader->itemidx++;
+	size_t nparsed = 0;
 
-	err = parse(ctx, expected_items);
-	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
-		if (err != CBOR_SUCCESS) {
-			return err;
-		} else if (ctx->reader->itemidx >= ctx->reader->maxitems) {
-			return CBOR_OVERRUN;
-		}
-		return CBOR_ILLEGAL;
-	} else if (err != CBOR_SUCCESS) {
+	if ((err = parse(ctx, expected_items, &nparsed)) != CBOR_SUCCESS) {
 		return err;
 	}
 
-	if ((ctx->reader->itemidx - nitems_before - 1) < expected_items) {
+	if (len == (size_t)CBOR_INDEFINITE_VALUE || nparsed < expected_items) {
 		if (ctx->reader->itemidx >= ctx->reader->maxitems) {
 			return CBOR_OVERRUN;
 		}
@@ -272,7 +269,7 @@ cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
 		.dry_run = false,
 	};
 
-	cbor_error_t err = parse(&ctx, reader->maxitems);
+	cbor_error_t err = parse(&ctx, reader->maxitems, NULL);
 
 	if (err == CBOR_SUCCESS && reader->msgidx < reader->msgsize) {
 		err = CBOR_OVERRUN;
@@ -306,7 +303,7 @@ cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
 	 * reader.maxitems == (size_t)-1 conflicts with BREAK sentinel behavior
 	 * and can terminate early. msgsize is a safe upper bound; long-term,
 	 * split maxitems and break policy in parse(). */
-	cbor_error_t err = parse(&ctx, reader.msgsize);
+	cbor_error_t err = parse(&ctx, reader.msgsize, NULL);
 
 	if (err == CBOR_SUCCESS && reader.msgidx < reader.msgsize) {
 		err = CBOR_OVERRUN;

--- a/src/parser.c
+++ b/src/parser.c
@@ -94,17 +94,9 @@ static bool should_stop_on_break(uint8_t val, size_t maxitems,
 	return (direct && indefinite) || at_end;
 }
 
-static bool is_top_level_break_at_end(const struct parser_context *ctx)
+static bool is_illegal_break(uint8_t val, size_t maxitems)
 {
-	return ctx->recursion_depth == 1 &&
-		ctx->reader->msgidx == ctx->reader->msgsize;
-}
-
-static bool is_illegal_break(uint8_t val, size_t maxitems,
-			     const struct parser_context *ctx)
-{
-	return val == 0xff && maxitems != (size_t)CBOR_INDEFINITE_VALUE &&
-		!is_top_level_break_at_end(ctx);
+	return val == 0xff && maxitems != (size_t)CBOR_INDEFINITE_VALUE;
 }
 
 static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
@@ -137,7 +129,7 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 		err = parsers[ctx->major_type](ctx);
 
 		if (err == CBOR_BREAK) {
-			if (is_illegal_break(val, maxitems, ctx)) {
+			if (is_illegal_break(val, maxitems)) {
 				err = CBOR_ILLEGAL;
 				break;
 			} else if (should_stop_on_break(val, maxitems, ctx)) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -57,7 +57,7 @@ static bool has_valid_following_bytes(const struct parser_context *ctx,
 	}
 
 	if ((ctx->following_bytes + 1u)
-			> ctx->reader->msgsize - ctx->reader->msgidx) {
+			> (ctx->reader->msgsize - ctx->reader->msgidx)) {
 		*err = CBOR_ILLEGAL;
 		return false;
 	}
@@ -94,10 +94,11 @@ static bool should_stop_on_break(uint8_t val, size_t maxitems,
 	return (direct && indefinite) || at_end;
 }
 
-static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
-		size_t *nitems_parsed)
+static cbor_error_t parse(struct parser_context *ctx,
+		size_t maxitems, size_t *nitems_parsed)
 {
 	cbor_error_t err = CBOR_SUCCESS;
+	uint8_t last_val = 0;
 	size_t i;
 
 	if (ctx->recursion_depth >= CBOR_RECURSION_MAX_LEVEL) {
@@ -109,7 +110,8 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 	for (i = 0; i < maxitems &&
 			ctx->reader->itemidx < ctx->reader->maxitems &&
 			ctx->reader->msgidx < ctx->reader->msgsize; i++) {
-		uint8_t val = ctx->reader->msg[ctx->reader->msgidx];
+		const uint8_t val = ctx->reader->msg[ctx->reader->msgidx];
+		last_val = val;
 		ctx->major_type = get_cbor_major_type(val);
 		ctx->additional_info = get_cbor_additional_info(val);
 		ctx->following_bytes =
@@ -134,7 +136,11 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 
 	ctx->recursion_depth--;
 	if (nitems_parsed != NULL) {
-		*nitems_parsed = i;
+		/* When stopped by BREAK from a sub-container (last_val is not
+		 * the BREAK byte 0xff itself), the item at index i was fully
+		 * parsed, so the actual count is i+1. */
+		*nitems_parsed = (err == CBOR_BREAK && last_val != 0xff)
+				? i + 1 : i;
 	}
 
 	assert(ctx->reader->msgidx <= ctx->reader->msgsize);
@@ -142,8 +148,8 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 	return err;
 }
 
-static void set_item(struct parser_context *ctx, cbor_item_data_t type,
-		     size_t offset, size_t size)
+static void set_item(struct parser_context *ctx,
+		cbor_item_data_t type, size_t offset, size_t size)
 {
 	if (ctx->dry_run) {
 		return;
@@ -217,6 +223,10 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	size_t nparsed = 0;
 
 	if ((err = parse(ctx, expected_items, &nparsed)) != CBOR_SUCCESS) {
+		if (err == CBOR_BREAK && len != (size_t)CBOR_INDEFINITE_VALUE
+				&& nparsed < expected_items) {
+			return CBOR_ILLEGAL;
+		}
 		return err;
 	}
 
@@ -263,8 +273,8 @@ static cbor_error_t do_float_and_other(struct parser_context *ctx)
 	return err;
 }
 
-cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
-		size_t *nitems_parsed)
+cbor_error_t cbor_parse(cbor_reader_t *reader,
+		void const *msg, size_t msgsize, size_t *nitems_parsed)
 {
 	assert(reader->items != NULL);
 	reader->itemidx = 0;

--- a/src/parser.c
+++ b/src/parser.c
@@ -100,6 +100,12 @@ static bool is_illegal_break(uint8_t val, size_t maxitems)
 	return val == 0xff && maxitems != (size_t)CBOR_INDEFINITE_VALUE;
 }
 
+static bool is_item_buffer_overrun(const struct parser_context *ctx)
+{
+	return ctx->reader->itemidx >= ctx->reader->maxitems &&
+		ctx->reader->msgidx < ctx->reader->msgsize;
+}
+
 static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 			  size_t *nitems_parsed)
 {
@@ -197,7 +203,7 @@ static cbor_error_t do_string(struct parser_context *ctx)
 		err = parse(ctx, (size_t)CBOR_INDEFINITE_VALUE, NULL);
 		if (err != CBOR_SUCCESS) {
 			return err;
-		} else if (ctx->reader->itemidx >= ctx->reader->maxitems) {
+		} else if (is_item_buffer_overrun(ctx)) {
 			return CBOR_OVERRUN;
 		}
 		return CBOR_ILLEGAL;
@@ -242,7 +248,7 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	}
 
 	if (len == (size_t)CBOR_INDEFINITE_VALUE || nparsed < expected_items) {
-		if (ctx->reader->itemidx >= ctx->reader->maxitems) {
+		if (is_item_buffer_overrun(ctx)) {
 			return CBOR_OVERRUN;
 		}
 		return CBOR_ILLEGAL;

--- a/src/parser.c
+++ b/src/parser.c
@@ -232,9 +232,11 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	size_t nparsed = 0;
 
 	if ((err = parse(ctx, expected_items, &nparsed)) != CBOR_SUCCESS) {
-		if (err == CBOR_BREAK && len != (size_t)CBOR_INDEFINITE_VALUE
-				&& nparsed < expected_items) {
-			return CBOR_ILLEGAL;
+		if (err == CBOR_BREAK && len != (size_t)CBOR_INDEFINITE_VALUE) {
+			if (nparsed < expected_items) {
+				return CBOR_ILLEGAL;
+			}
+			return CBOR_SUCCESS;
 		}
 		return err;
 	}

--- a/src/parser.c
+++ b/src/parser.c
@@ -159,12 +159,17 @@ static cbor_error_t do_integer(struct parser_context *ctx)
 static cbor_error_t do_string(struct parser_context *ctx)
 {
 	size_t len = go_get_item_length(ctx);
+	cbor_error_t err;
 
 	set_item(ctx, CBOR_ITEM_STRING, ctx->reader->msgidx, len);
 
 	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
 		ctx->reader->itemidx++;
-		return parse(ctx, ctx->reader->maxitems - ctx->reader->itemidx);
+		err = parse(ctx, ctx->reader->maxitems - ctx->reader->itemidx);
+		if (err != CBOR_BREAK) {
+			return CBOR_ILLEGAL;
+		}
+		return CBOR_BREAK;
 	}
 	if (len > ctx->reader->msgsize - ctx->reader->msgidx) {
 		return CBOR_ILLEGAL;
@@ -179,17 +184,37 @@ static cbor_error_t do_string(struct parser_context *ctx)
 static cbor_error_t do_recursive(struct parser_context *ctx)
 {
 	size_t len = go_get_item_length(ctx);
+	size_t expected_items = len;
+	size_t nitems_before = ctx->reader->itemidx;
+	cbor_error_t err;
 
 	set_item(ctx, (cbor_item_data_t)(ctx->major_type - 1),
 			ctx->reader->msgidx, len);
-	if (len != (size_t)CBOR_INDEFINITE_VALUE &&
-			len > ctx->reader->msgsize - ctx->reader->msgidx) {
-		return CBOR_ILLEGAL;
+	if (len != (size_t)CBOR_INDEFINITE_VALUE && (cbor_item_data_t)
+			(ctx->major_type - 1) == CBOR_ITEM_MAP) {
+		if (len > SIZE_MAX / 2) {
+			return CBOR_ILLEGAL;
+		}
+		expected_items = len * 2;
 	}
 
 	ctx->reader->itemidx++;
 
-	return parse(ctx, len);
+	err = parse(ctx, expected_items);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	} else if (len == (size_t)CBOR_INDEFINITE_VALUE) {
+		return CBOR_ILLEGAL;
+	}
+
+	if ((ctx->reader->itemidx - nitems_before - 1) < expected_items) {
+		if (ctx->reader->itemidx >= ctx->reader->maxitems) {
+			return CBOR_OVERRUN;
+		}
+		return CBOR_ILLEGAL;
+	}
+
+	return CBOR_SUCCESS;
 }
 
 /* TODO: Implement tag */
@@ -270,7 +295,11 @@ cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
 		.dry_run = true,
 	};
 
-	cbor_error_t err = parse(&ctx, reader.maxitems);
+	/* Use reader.msgsize as top-level maxitems in dry-run counting.
+	 * reader.maxitems == (size_t)-1 conflicts with BREAK sentinel behavior
+	 * and can terminate early. msgsize is a safe upper bound; long-term,
+	 * split maxitems and break policy in parse(). */
+	cbor_error_t err = parse(&ctx, reader.msgsize);
 
 	if (err == CBOR_SUCCESS && reader.msgidx < reader.msgsize) {
 		err = CBOR_OVERRUN;

--- a/src/parser.c
+++ b/src/parser.c
@@ -85,6 +85,15 @@ static size_t go_get_item_length(struct parser_context *ctx)
 	return (size_t)len;
 }
 
+static bool should_stop_on_break(uint8_t val, size_t maxitems,
+		const struct parser_context *ctx)
+{
+	const bool direct = (val == 0xff); /* BREAK(major 7, add-info 31) */
+	const bool indefinite = (maxitems == (size_t)CBOR_INDEFINITE_VALUE);
+	const bool at_end = (ctx->reader->msgidx == ctx->reader->msgsize);
+	return (direct && indefinite) || at_end;
+}
+
 static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 		size_t *nitems_parsed)
 {
@@ -113,9 +122,7 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 		err = parsers[ctx->major_type](ctx);
 
 		if (err == CBOR_BREAK) {
-			if ((maxitems == (size_t)CBOR_INDEFINITE_VALUE) ||
-					(ctx->reader->msgidx ==
-						ctx->reader->msgsize)) {
+			if (should_stop_on_break(val, maxitems, ctx)) {
 				break;
 			}
 		} else if (err != CBOR_SUCCESS) {
@@ -301,12 +308,13 @@ cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
 		.dry_run = true,
 	};
 
-	/* Use reader.msgsize as top-level maxitems in dry-run counting.
-	 * reader.maxitems == (size_t)-1 conflicts with BREAK sentinel behavior
-	 * and can terminate early. msgsize is a safe upper bound; long-term,
-	 * split maxitems and break policy in parse(). */
 	cbor_error_t err = parse(&ctx, reader.msgsize, NULL);
 
+	/* CBOR_BREAK means the message contained indefinite-length items;
+	 * that is valid for counting purposes. */
+	if (err == CBOR_BREAK) {
+		err = CBOR_SUCCESS;
+	}
 	if (err == CBOR_SUCCESS && reader.msgidx < reader.msgsize) {
 		err = CBOR_OVERRUN;
 	}

--- a/src/parser.c
+++ b/src/parser.c
@@ -90,7 +90,8 @@ static bool should_stop_on_break(uint8_t val, size_t maxitems,
 {
 	const bool direct = (val == 0xff); /* BREAK(major 7, add-info 31) */
 	const bool indefinite = (maxitems == (size_t)CBOR_INDEFINITE_VALUE);
-	const bool at_end = (ctx->reader->msgidx == ctx->reader->msgsize);
+	const bool at_end = !indefinite &&
+			(ctx->reader->msgidx == ctx->reader->msgsize);
 	return (direct && indefinite) || at_end;
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -20,6 +20,8 @@ struct parser_context {
 
 	uint8_t recursion_depth;
 	_Static_assert(CBOR_RECURSION_MAX_LEVEL < 256, "");
+
+	bool dry_run;
 };
 
 typedef cbor_error_t (*type_parser_t)(struct parser_context *ctx);
@@ -126,16 +128,27 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems)
 	return err;
 }
 
+static void set_item(struct parser_context *ctx, cbor_item_data_t type,
+		     size_t offset, size_t size)
+{
+	if (ctx->dry_run) {
+		return;
+	}
+
+	cbor_item_t *item = &ctx->reader->items[ctx->reader->itemidx];
+	item->type = type;
+	item->size = size;
+	item->offset = offset;
+}
+
 static cbor_error_t do_integer(struct parser_context *ctx)
 {
 	if (ctx->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
 		return CBOR_ILLEGAL;
 	}
 
-	cbor_item_t *item = &ctx->reader->items[ctx->reader->itemidx];
-	item->type = CBOR_ITEM_INTEGER;
-	item->size = (size_t)ctx->following_bytes;
-	item->offset = ctx->reader->msgidx;
+	set_item(ctx, CBOR_ITEM_INTEGER, ctx->reader->msgidx,
+			(size_t)ctx->following_bytes);
 
 	ctx->reader->msgidx += (size_t)(ctx->following_bytes + 1);
 	ctx->reader->itemidx++;
@@ -145,12 +158,9 @@ static cbor_error_t do_integer(struct parser_context *ctx)
 
 static cbor_error_t do_string(struct parser_context *ctx)
 {
-	cbor_item_t *item = &ctx->reader->items[ctx->reader->itemidx];
 	size_t len = go_get_item_length(ctx);
 
-	item->type = CBOR_ITEM_STRING;
-	item->size = len;
-	item->offset = ctx->reader->msgidx;
+	set_item(ctx, CBOR_ITEM_STRING, ctx->reader->msgidx, len);
 
 	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
 		ctx->reader->itemidx++;
@@ -168,13 +178,10 @@ static cbor_error_t do_string(struct parser_context *ctx)
 
 static cbor_error_t do_recursive(struct parser_context *ctx)
 {
-	size_t current_item_index = ctx->reader->itemidx;
-	cbor_item_t *item = &ctx->reader->items[current_item_index];
 	size_t len = go_get_item_length(ctx);
 
-	item->type = (cbor_item_data_t)(ctx->major_type - 1);
-	item->offset = ctx->reader->msgidx;
-	item->size = len;
+	set_item(ctx, (cbor_item_data_t)(ctx->major_type - 1),
+			ctx->reader->msgidx, len);
 	if (len != (size_t)CBOR_INDEFINITE_VALUE &&
 			len > ctx->reader->msgsize - ctx->reader->msgidx) {
 		return CBOR_ILLEGAL;
@@ -194,12 +201,15 @@ static cbor_error_t do_tag(struct parser_context *ctx)
 
 static cbor_error_t do_float_and_other(struct parser_context *ctx)
 {
-	cbor_item_t *item = &ctx->reader->items[ctx->reader->itemidx];
 	cbor_error_t err = CBOR_SUCCESS;
+	cbor_item_data_t type = CBOR_ITEM_FLOAT;
+	size_t size = (size_t)ctx->following_bytes;
 
-	item->type = CBOR_ITEM_FLOAT;
-	item->size = (size_t)ctx->following_bytes;
-	item->offset = ctx->reader->msgidx;
+	if (ctx->following_bytes <= 1 &&
+			ctx->following_bytes != (uint8_t)CBOR_INDEFINITE_VALUE) {
+		type = CBOR_ITEM_SIMPLE_VALUE;
+	}
+	set_item(ctx, type, ctx->reader->msgidx, size);
 
 	if (ctx->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
 		ctx->reader->msgidx++;
@@ -207,11 +217,9 @@ static cbor_error_t do_float_and_other(struct parser_context *ctx)
 		return CBOR_BREAK;
 	} else if (!has_valid_following_bytes(ctx, &err)) {
 		return err;
-	} else if (ctx->following_bytes <= 1) {
-		item->type = CBOR_ITEM_SIMPLE_VALUE;
 	}
 
-	ctx->reader->msgidx += item->size + 1;
+	ctx->reader->msgidx += size + 1;
 	ctx->reader->itemidx++;
 
 	return err;
@@ -229,6 +237,7 @@ cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
 
 	struct parser_context ctx = {
 		.reader = reader,
+		.dry_run = false,
 	};
 
 	cbor_error_t err = parse(&ctx, reader->maxitems);
@@ -239,6 +248,36 @@ cbor_error_t cbor_parse(cbor_reader_t *reader, void const *msg, size_t msgsize,
 
 	if (nitems_parsed != NULL) {
 		*nitems_parsed = reader->itemidx;
+	}
+
+	return err;
+}
+
+cbor_error_t cbor_count_items(void const *msg, size_t msgsize,
+		size_t *nitems_counted)
+{
+	cbor_reader_t reader = {
+		.msg = (uint8_t const *)msg,
+		.msgsize = msgsize,
+		.msgidx = 0,
+		.items = NULL,
+		.itemidx = 0,
+		.maxitems = (size_t)-1,
+	};
+
+	struct parser_context ctx = {
+		.reader = &reader,
+		.dry_run = true,
+	};
+
+	cbor_error_t err = parse(&ctx, reader.maxitems);
+
+	if (err == CBOR_SUCCESS && reader.msgidx < reader.msgsize) {
+		err = CBOR_OVERRUN;
+	}
+
+	if (nitems_counted != NULL) {
+		*nitems_counted = reader.itemidx;
 	}
 
 	return err;

--- a/src/parser.c
+++ b/src/parser.c
@@ -165,11 +165,13 @@ static cbor_error_t do_string(struct parser_context *ctx)
 
 	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
 		ctx->reader->itemidx++;
-		err = parse(ctx, ctx->reader->maxitems - ctx->reader->itemidx);
-		if (err != CBOR_BREAK) {
-			return CBOR_ILLEGAL;
+		err = parse(ctx, (size_t)CBOR_INDEFINITE_VALUE);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		} else if (ctx->reader->itemidx >= ctx->reader->maxitems) {
+			return CBOR_OVERRUN;
 		}
-		return CBOR_BREAK;
+		return CBOR_ILLEGAL;
 	}
 	if (len > ctx->reader->msgsize - ctx->reader->msgidx) {
 		return CBOR_ILLEGAL;
@@ -201,10 +203,15 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	ctx->reader->itemidx++;
 
 	err = parse(ctx, expected_items);
-	if (err != CBOR_SUCCESS) {
-		return err;
-	} else if (len == (size_t)CBOR_INDEFINITE_VALUE) {
+	if (len == (size_t)CBOR_INDEFINITE_VALUE) {
+		if (err != CBOR_SUCCESS) {
+			return err;
+		} else if (ctx->reader->itemidx >= ctx->reader->maxitems) {
+			return CBOR_OVERRUN;
+		}
 		return CBOR_ILLEGAL;
+	} else if (err != CBOR_SUCCESS) {
+		return err;
 	}
 
 	if ((ctx->reader->itemidx - nitems_before - 1) < expected_items) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -94,8 +94,21 @@ static bool should_stop_on_break(uint8_t val, size_t maxitems,
 	return (direct && indefinite) || at_end;
 }
 
-static cbor_error_t parse(struct parser_context *ctx,
-		size_t maxitems, size_t *nitems_parsed)
+static bool is_top_level_break_at_end(const struct parser_context *ctx)
+{
+	return ctx->recursion_depth == 1 &&
+		ctx->reader->msgidx == ctx->reader->msgsize;
+}
+
+static bool is_illegal_break(uint8_t val, size_t maxitems,
+			     const struct parser_context *ctx)
+{
+	return val == 0xff && maxitems != (size_t)CBOR_INDEFINITE_VALUE &&
+		!is_top_level_break_at_end(ctx);
+}
+
+static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
+			  size_t *nitems_parsed)
 {
 	cbor_error_t err = CBOR_SUCCESS;
 	uint8_t last_val = 0;
@@ -124,7 +137,10 @@ static cbor_error_t parse(struct parser_context *ctx,
 		err = parsers[ctx->major_type](ctx);
 
 		if (err == CBOR_BREAK) {
-			if (should_stop_on_break(val, maxitems, ctx)) {
+			if (is_illegal_break(val, maxitems, ctx)) {
+				err = CBOR_ILLEGAL;
+				break;
+			} else if (should_stop_on_break(val, maxitems, ctx)) {
 				break;
 			}
 		} else if (err != CBOR_SUCCESS) {
@@ -139,8 +155,8 @@ static cbor_error_t parse(struct parser_context *ctx,
 		/* When stopped by BREAK from a sub-container (last_val is not
 		 * the BREAK byte 0xff itself), the item at index i was fully
 		 * parsed, so the actual count is i+1. */
-		*nitems_parsed = (err == CBOR_BREAK && last_val != 0xff)
-				? i + 1 : i;
+		*nitems_parsed = (err == CBOR_BREAK && last_val != 0xff) ?
+			i + 1 : i;
 	}
 
 	assert(ctx->reader->msgidx <= ctx->reader->msgsize);

--- a/src/parser.c
+++ b/src/parser.c
@@ -91,9 +91,11 @@ static cbor_error_t parse(struct parser_context *ctx, size_t maxitems,
 	cbor_error_t err = CBOR_SUCCESS;
 	size_t i;
 
-	if (++ctx->recursion_depth > CBOR_RECURSION_MAX_LEVEL) {
+	if (ctx->recursion_depth >= CBOR_RECURSION_MAX_LEVEL) {
 		return CBOR_EXCESSIVE;
 	}
+
+	ctx->recursion_depth++;
 
 	for (i = 0; i < maxitems &&
 			ctx->reader->itemidx < ctx->reader->maxitems &&

--- a/tests/runners/decoder.mk
+++ b/tests/runners/decoder.mk
@@ -18,7 +18,7 @@ INCLUDE_DIRS = \
 	$(CPPUTEST_HOME)/include \
 
 MOCKS_SRC_DIRS =
-CPPUTEST_CPPFLAGS = \
+CPPUTEST_CPPFLAGS += \
 	-DCBOR_PROJECT_ROOT=\"$(abspath ..)\"
 
 include MakefileRunner.mk

--- a/tests/runners/decoder.mk
+++ b/tests/runners/decoder.mk
@@ -9,6 +9,7 @@ SRC_FILES = \
 
 TEST_SRC_FILES = \
 	src/decoder_test.cpp \
+	src/parser_count_test.cpp \
 	src/test_all.cpp \
 
 INCLUDE_DIRS = \

--- a/tests/runners/decoder.mk
+++ b/tests/runners/decoder.mk
@@ -10,6 +10,7 @@ SRC_FILES = \
 TEST_SRC_FILES = \
 	src/decoder_test.cpp \
 	src/parser_count_test.cpp \
+	src/tool_item_count_test.cpp \
 	src/test_all.cpp \
 
 INCLUDE_DIRS = \

--- a/tests/runners/decoder.mk
+++ b/tests/runners/decoder.mk
@@ -18,6 +18,7 @@ INCLUDE_DIRS = \
 	$(CPPUTEST_HOME)/include \
 
 MOCKS_SRC_DIRS =
-CPPUTEST_CPPFLAGS =
+CPPUTEST_CPPFLAGS = \
+	-DCBOR_PROJECT_ROOT=\"$(abspath ..)\"
 
 include MakefileRunner.mk

--- a/tests/src/decoder_test.cpp
+++ b/tests/src/decoder_test.cpp
@@ -589,7 +589,7 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven3)
 	uint8_t m[] = { 0x83, 0x01, 0x82, 0x02, 0x03, 0x9f, 0x04, 0x05, 0xff };
 	size_t n;
 
-	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
 	LONGS_EQUAL(9, n);
 
 	mock().expectOneCall("f_array").withParameter("size", 3);
@@ -675,7 +675,7 @@ TEST(Decoder, ShouldDecodeArray_WhenInfiniteMapIncluded)
 	uint8_t m[] = { 0x82, 0x61, 0x61, 0xbf, 0x61, 0x62, 0x61, 0x63, 0xff };
 	size_t n;
 
-	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
 	LONGS_EQUAL(6, n);
 
 	mock().expectOneCall("f_array").withParameter("size", 2);

--- a/tests/src/decoder_test.cpp
+++ b/tests/src/decoder_test.cpp
@@ -17,46 +17,51 @@
 
 typedef void (*check_func_t)(size_t size);
 
-static void f_unknown(size_t size) {
+static void f_unknown(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_integer(size_t size) {
+static void f_integer(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_string(size_t size) {
+static void f_string(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_array(size_t size) {
+static void f_array(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_map(size_t size) {
+static void f_map(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_float(size_t size) {
+static void f_float(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
-static void f_simple(size_t size) {
+static void f_simple(size_t size)
+{
 	mock().actualCall(__func__).withParameter("size", size);
 }
 
 static check_func_t check_item_type[] = {
-	f_unknown,
-	f_integer,
-	f_string,
-	f_array,
-	f_map,
-	f_float,
-	f_simple,
+	f_unknown, f_integer, f_string, f_array, f_map, f_float, f_simple,
 };
 
-TEST_GROUP(Decoder) {
+TEST_GROUP(Decoder)
+{
 	cbor_reader_t reader;
 	cbor_item_t items[256];
 
-	void setup(void) {
-		cbor_reader_init(&reader, items, sizeof(items)/sizeof(*items));
+	void setup(void)
+	{
+		cbor_reader_init(&reader, items,
+				 sizeof(items) / sizeof(*items));
 	}
-	void teardown(void) {
+	void teardown(void)
+	{
 		mock().checkExpectations();
 		mock().clear();
 	}
@@ -64,21 +69,24 @@ TEST_GROUP(Decoder) {
 
 // most of test cases are brought from
 // https://www.rfc-editor.org/rfc/rfc8949.html#name-examples-of-encoded-cbor-da
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEncodedGiven) {
-	uint8_t m[] = { 0, 1, 10, 23};
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEncodedGiven)
+{
+	uint8_t m[] = { 0, 1, 10, 23 };
 	size_t n;
-	for (int i = 0; i < (int)(sizeof(m)/sizeof(m[0])); i++) {
-		LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m[i], sizeof(m[i]), &n));
+	for (int i = 0; i < (int)(sizeof(m) / sizeof(m[0])); i++) {
+		LONGS_EQUAL(CBOR_SUCCESS,
+			    cbor_parse(&reader, &m[i], sizeof(m[i]), &n));
 		LONGS_EQUAL(1, n);
 		LONGS_EQUAL(0, items[0].size);
 		LONGS_EQUAL(0, items[0].offset);
 		uint8_t v;
 		LONGS_EQUAL(CBOR_SUCCESS,
-				cbor_decode(&reader, &items[0], &v, sizeof(v)));
+			    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 		LONGS_EQUAL(m[i], v);
 	}
 }
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenOneByteValueGiven) {
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenOneByteValueGiven)
+{
 	uint8_t m1[] = { 0x18, 0x18 }; // 24
 	uint8_t m2[] = { 0x18, 0x19 }; // 25
 	uint8_t m3[] = { 0x18, 0x64 }; // 100
@@ -86,64 +94,82 @@ TEST(Decoder, ShouldDecodeUnsignedInteger_WhenOneByteValueGiven) {
 	uint8_t v;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m1, sizeof(m1), NULL));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(24, v);
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m2, sizeof(m2), NULL));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(25, v);
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m3, sizeof(m3), NULL));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(100, v);
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m4, sizeof(m4), NULL));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(255, v);
 }
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenTwoByteValueGiven) {
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenTwoByteValueGiven)
+{
 	uint8_t m[] = { 0x19, 0x03, 0xe8 }; // 1000
 	uint16_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(1000, v);
 }
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenFourByteValueGiven) {
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenFourByteValueGiven)
+{
 	uint8_t m[] = { 0x1a, 0x00, 0x0f, 0x42, 0x40 }; // 1000000
 	uint32_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(1000000, v);
 }
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEightByteValueGiven) {
-	uint8_t m[] = { 0x1b,0x00,0x00,0x00,0xe8,0xd4,0xa5,0x10,0x00 };
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEightByteValueGiven)
+{
+	uint8_t m[] = { 0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00 };
 	uint64_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGLONGS_EQUAL(1000000000000ull, v);
 }
-TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEightByteMaximumValueGiven) {
-	uint8_t m[] = { 0x1b,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff };
+TEST(Decoder, ShouldDecodeUnsignedInteger_WhenEightByteMaximumValueGiven)
+{
+	uint8_t m[] = { 0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 	uint64_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGLONGS_EQUAL(18446744073709551615ull, v);
 }
 
-TEST(Decoder, ShouldDecodeNegativeInteger_WhenEncodedValueGiven) {
+TEST(Decoder, ShouldDecodeNegativeInteger_WhenEncodedValueGiven)
+{
 	uint8_t m;
 	int8_t v;
 	m = 0x20;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(-1, v);
 	m = 0x29;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(-10, v);
 	m = 0x37;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(-24, v);
 }
-TEST(Decoder, ShouldDecodeNegativeInteger_EvenWhenDataTypeSizeLargerThanValueSize) {
+TEST(Decoder,
+     ShouldDecodeNegativeInteger_EvenWhenDataTypeSizeLargerThanValueSize)
+{
 	uint8_t m = 0x20;
 	int8_t v8;
 	int16_t v16;
@@ -151,73 +177,94 @@ TEST(Decoder, ShouldDecodeNegativeInteger_EvenWhenDataTypeSizeLargerThanValueSiz
 	int64_t v64;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v8, sizeof(v8)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v8, sizeof(v8)));
 	LONGS_EQUAL(-1, v8);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
 	LONGS_EQUAL(-1, v16);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v32, sizeof(v32)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v32, sizeof(v32)));
 	LONGS_EQUAL(-1, v32);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v64, sizeof(v64)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v64, sizeof(v64)));
 	LONGS_EQUAL(-1, v64);
 }
-TEST(Decoder, ShouldDecodeNegativeInteger_WhenOneByteValueGiven) {
+TEST(Decoder, ShouldDecodeNegativeInteger_WhenOneByteValueGiven)
+{
 	uint8_t m[] = { 0x38, 0x63 };
 	int8_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(-100, v);
 }
-TEST(Decoder, NegativeBecomesPositive_WhenDataTypeSizeIsSmallerThanValueSize) {
+TEST(Decoder, NegativeBecomesPositive_WhenDataTypeSizeIsSmallerThanValueSize)
+{
 	uint8_t m1[] = { 0x38, 0x80 };
 	uint8_t m2[] = { 0x38, 0xff };
 	int8_t v;
 	int16_t v16;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m1, sizeof(m1), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(0x7f, v);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
 	LONGS_EQUAL(-129, v16);
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m2, sizeof(m2), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(0, v);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v16, sizeof(v16)));
 	LONGS_EQUAL(-256, v16);
 }
-TEST(Decoder, ShouldDecodeNegativeInteger_WhenTwoByteValueGiven) {
+TEST(Decoder, ShouldDecodeNegativeInteger_WhenTwoByteValueGiven)
+{
 	uint8_t m[] = { 0x39, 0x03, 0xe7 };
 	int16_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(-1000, v);
 }
-TEST(Decoder, ShouldDecodeNegativeInteger_WhenEightByteValueGiven) {
+TEST(Decoder, ShouldDecodeNegativeInteger_WhenEightByteValueGiven)
+{
 	// -9223372036854775808 ~ 9223372036854775807
-	uint8_t m[] = { 0x3b,0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff };
+	uint8_t m[] = { 0x3b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 	int64_t v;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGLONGS_EQUAL(0x8000000000000000, v);
 }
 
-TEST(Decoder, ShouldDecodeByteString) {
+TEST(Decoder, ShouldDecodeByteString)
+{
 	uint8_t expected[] = { 1, 2, 3, 4 };
-	uint8_t m[] = { 0x44,0x01,0x02,0x03,0x04 };
+	uint8_t m[] = { 0x44, 0x01, 0x02, 0x03, 0x04 };
 	uint8_t buf[sizeof(expected)];
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], buf, sizeof(buf)));
 	MEMCMP_EQUAL(expected, buf, sizeof(expected));
 }
-TEST(Decoder, ShouldDecodeByteString_WhenZeroLengthStringGiven) {
+TEST(Decoder, ShouldDecodeByteString_WhenZeroLengthStringGiven)
+{
 	uint8_t m;
 	uint8_t v;
 	m = 0x40;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, &m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], &v, sizeof(v)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], &v, sizeof(v)));
 	LONGS_EQUAL(0, v);
 }
-TEST(Decoder, ShouldDecodeTextString_WhenWrappedInArray) {
-	uint8_t m[] = { 0x84,0x61,0x61,0x61,0x62,0x01,0x64,0xf0,0x9f,0x98,0x80 };
+TEST(Decoder, ShouldDecodeTextString_WhenWrappedInArray)
+{
+	uint8_t m[] = { 0x84, 0x61, 0x61, 0x61, 0x62, 0x01,
+			0x64, 0xf0, 0x9f, 0x98, 0x80 };
 	uint8_t buf[sizeof(m)];
 	size_t n;
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -229,20 +276,26 @@ TEST(Decoder, ShouldDecodeTextString_WhenWrappedInArray) {
 	LONGS_EQUAL(0, items[3].size); // unsigned
 	LONGS_EQUAL(4, items[4].size); // text
 
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[0], buf, sizeof(buf)));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[1], buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[0], buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[1], buf, sizeof(buf)));
 	MEMCMP_EQUAL("a", buf, 1);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[2], buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[2], buf, sizeof(buf)));
 	MEMCMP_EQUAL("b", buf, 1);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[3], buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[3], buf, sizeof(buf)));
 	LONGS_EQUAL(1, buf[0]);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[4], buf, sizeof(buf)));
-	uint8_t expected[] = { 0xF0,0x9F,0x98,0x80 };
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[4], buf, sizeof(buf)));
+	uint8_t expected[] = { 0xF0, 0x9F, 0x98, 0x80 };
 	MEMCMP_EQUAL(expected, buf, sizeof(expected));
 }
 
-TEST(Decoder, ShouldDecodeArray_WhenSingleLevelArrayGiven) {
-	uint8_t m[] = { 0x83,0x01,0x02,0x03 };
+TEST(Decoder, ShouldDecodeArray_WhenSingleLevelArrayGiven)
+{
+	uint8_t m[] = { 0x83, 0x01, 0x02, 0x03 };
 	uint8_t v;
 	size_t n;
 
@@ -251,20 +304,25 @@ TEST(Decoder, ShouldDecodeArray_WhenSingleLevelArrayGiven) {
 	LONGS_EQUAL(CBOR_ITEM_ARRAY, items[0].type);
 	for (size_t i = 1; i < n; i++) {
 		LONGS_EQUAL(CBOR_SUCCESS,
-				cbor_decode(&reader, &items[i], &v, sizeof(v)));
+			    cbor_decode(&reader, &items[i], &v, sizeof(v)));
 		LONGS_EQUAL(i, v);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenEmptyArrayGiven) {
+TEST(Decoder, ShouldDecodeArray_WhenEmptyArrayGiven)
+{
 	uint8_t expected[] = { 0 };
 	uint8_t m[] = { 0x80 };
-	uint8_t buf[1] = { 0, };
+	uint8_t buf[1] = {
+		0,
+	};
 	cbor_parse(&reader, m, sizeof(m), 0);
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, items, buf, sizeof(buf)));
 	MEMCMP_EQUAL(expected, buf, sizeof(expected));
 }
-TEST(Decoder, ShouldDecodeArray_WhenSingleLevelWithDiffentTypeValueGiven) {
-	uint8_t m[] = { 0x83,0x01,0x63,0x61,0x62,0x63,0x03 };
+TEST(Decoder, ShouldDecodeArray_WhenSingleLevelWithDiffentTypeValueGiven)
+{
+	uint8_t m[] = { 0x83, 0x01, 0x63, 0x61, 0x62, 0x63, 0x03 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -278,8 +336,9 @@ TEST(Decoder, ShouldDecodeArray_WhenSingleLevelWithDiffentTypeValueGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenMultiLevelArrayGiven) {
-	uint8_t m[] = { 0x83,0x01,0x82,0x02,0x03,0x82,0x04,0x05 };
+TEST(Decoder, ShouldDecodeArray_WhenMultiLevelArrayGiven)
+{
+	uint8_t m[] = { 0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -296,11 +355,13 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelArrayGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenOneByteLengthGiven) {
+TEST(Decoder, ShouldDecodeArray_WhenOneByteLengthGiven)
+{
 	// [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-	uint8_t m[] = { 0x98,0x19,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,
-		0x0a,0x0b,0x0c,0x0d,0x0e,0x0f,0x10,0x11,0x12,0x13,0x14,0x15,
-		0x16,0x17,0x18,0x18,0x18,0x19 };
+	uint8_t m[] = { 0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+			0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+			0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+			0x17, 0x18, 0x18, 0x18, 0x19 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -315,8 +376,9 @@ TEST(Decoder, ShouldDecodeArray_WhenOneByteLengthGiven) {
 	}
 }
 
-TEST(Decoder, ShouldDecodeMap_WhenSingleLevelArrayGiven) {
-	uint8_t m[] = { 0xa2,0x01,0x02,0x03,0x04 };
+TEST(Decoder, ShouldDecodeMap_WhenSingleLevelArrayGiven)
+{
+	uint8_t m[] = { 0xa2, 0x01, 0x02, 0x03, 0x04 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -329,17 +391,23 @@ TEST(Decoder, ShouldDecodeMap_WhenSingleLevelArrayGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeMap_WhenEmptyMapGiven) {
+TEST(Decoder, ShouldDecodeMap_WhenEmptyMapGiven)
+{
 	uint8_t m[] = { 0xa0 };
-	uint8_t buf[1] = { 0, };
+	uint8_t buf[1] = {
+		0,
+	};
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, buf, sizeof(buf)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, items, buf, sizeof(buf)));
 }
-TEST(Decoder, ShouldDecodeMap_WhenEncodedLenGiven) {
+TEST(Decoder, ShouldDecodeMap_WhenEncodedLenGiven)
+{
 	// {"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}
-	uint8_t m[] = { 0xa5,0x61,0x61,0x61,0x41,0x61,0x62,0x61,0x42,0x61,0x63,
-		0x61,0x43,0x61,0x64,0x61,0x44,0x61,0x65,0x61,0x45 };
+	uint8_t m[] = { 0xa5, 0x61, 0x61, 0x61, 0x41, 0x61, 0x62,
+			0x61, 0x42, 0x61, 0x63, 0x61, 0x43, 0x61,
+			0x64, 0x61, 0x44, 0x61, 0x65, 0x61, 0x45 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -352,9 +420,10 @@ TEST(Decoder, ShouldDecodeMap_WhenEncodedLenGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeMap_WhenArrayValueGiven) {
+TEST(Decoder, ShouldDecodeMap_WhenArrayValueGiven)
+{
 	// {"a": 1, "b": [2, 3]}
-	uint8_t m[] = { 0xa2,0x61,0x61,0x01,0x61,0x62,0x82,0x02,0x03 };
+	uint8_t m[] = { 0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -372,19 +441,18 @@ TEST(Decoder, ShouldDecodeMap_WhenArrayValueGiven) {
 	}
 }
 
-TEST(Decoder, ShouldReturnBreak_WhenBreakGiven) {
-	uint8_t expected[] = { 0 };
+TEST(Decoder, ShouldReturnIllegal_WhenStandaloneBreakGiven)
+{
 	uint8_t m[] = { 0xff };
-	uint8_t buf[sizeof(expected)] = { 0, };
+	size_t n = 0;
 
-	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), 0));
-	LONGS_EQUAL(CBOR_BREAK, cbor_decode(&reader, items, buf, sizeof(buf)));
-	MEMCMP_EQUAL(expected, buf, sizeof(expected));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, m, sizeof(m), &n));
 }
-TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven) {
+TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven)
+{
 	// (_ h'F09FA7ACF09F9098', h'63626F72')
-	uint8_t m[] = { 0x5f,0x48,0xf0,0x9f,0xa7,0xac,0xf0,0x9f,
-		0x90,0x98,0x44,0x63,0x62,0x6f,0x72,0xff };
+	uint8_t m[] = { 0x5f, 0x48, 0xf0, 0x9f, 0xa7, 0xac, 0xf0, 0x9f,
+			0x90, 0x98, 0x44, 0x63, 0x62, 0x6f, 0x72, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -399,10 +467,11 @@ TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteTextStringGiven) {
+TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteTextStringGiven)
+{
 	// (_ "\u{1F9EC}\ud83d\udc18", "cbor")
-	uint8_t m[] = { 0x7f,0x68,0xf0,0x9f,0xa7,0xac,0xf0,0x9f,
-		0x90,0x98,0x64,0x63,0x62,0x6f,0x72,0xff };
+	uint8_t m[] = { 0x7f, 0x68, 0xf0, 0x9f, 0xa7, 0xac, 0xf0, 0x9f,
+			0x90, 0x98, 0x64, 0x63, 0x62, 0x6f, 0x72, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -418,9 +487,10 @@ TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteTextStringGiven) {
 	}
 }
 
-TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven2) {
+TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven2)
+{
 	// (_ h'0102', h'030405')
-	uint8_t m[] = { 0x5f,0x42,0x01,0x02,0x43,0x03,0x04,0x05,0xff };
+	uint8_t m[] = { 0x5f, 0x42, 0x01, 0x02, 0x43, 0x03, 0x04, 0x05, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -435,9 +505,11 @@ TEST(Decoder, ShouldDecodeByteString_WhenIndefiniteByteGiven2) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteStringGiven) {
+TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteStringGiven)
+{
 	// (_ "strea", "ming")
-	uint8_t m[] = {	0x7f,0x65,0x73,0x74,0x72,0x65,0x61,0x64,0x6d,0x69,0x6e,0x67,0xff };
+	uint8_t m[] = { 0x7f, 0x65, 0x73, 0x74, 0x72, 0x65, 0x61,
+			0x64, 0x6d, 0x69, 0x6e, 0x67, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -452,7 +524,8 @@ TEST(Decoder, ShouldDecodeTextString_WhenIndefiniteStringGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeEmptyLengthArray_WhenZeroLengthIndefiniteArrarGiven) {
+TEST(Decoder, ShouldDecodeEmptyLengthArray_WhenZeroLengthIndefiniteArrarGiven)
+{
 	uint8_t m[] = { 0x9f, 0xff };
 	size_t n;
 
@@ -466,9 +539,11 @@ TEST(Decoder, ShouldDecodeEmptyLengthArray_WhenZeroLengthIndefiniteArrarGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven) {
+TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven)
+{
 	// [1, [2, 3], [4, 5]]
-	uint8_t m[] = { 0x9f,0x01,0x82,0x02,0x03,0x9f,0x04,0x05,0xff,0xff };
+	uint8_t m[] = { 0x9f, 0x01, 0x82, 0x02, 0x03,
+			0x9f, 0x04, 0x05, 0xff, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -487,9 +562,10 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven2) {
+TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven2)
+{
 	// [1, [2, 3], [4, 5]]
-	uint8_t m[] = { 0x9f,0x01,0x82,0x02,0x03,0x82,0x04,0x05,0xff };
+	uint8_t m[] = { 0x9f, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -507,9 +583,10 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven2) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven3) {
+TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven3)
+{
 	// [1, [2, 3], [4, 5]]
-	uint8_t m[] = { 0x83,0x01,0x82,0x02,0x03,0x9f,0x04,0x05,0xff };
+	uint8_t m[] = { 0x83, 0x01, 0x82, 0x02, 0x03, 0x9f, 0x04, 0x05, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -527,9 +604,10 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven3) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven4) {
+TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven4)
+{
 	// [1, [2, 3], [4, 5]]
-	uint8_t m[] = { 0x83,0x01,0x9f,0x02,0x03,0xff,0x82,0x04,0x05 };
+	uint8_t m[] = { 0x83, 0x01, 0x9f, 0x02, 0x03, 0xff, 0x82, 0x04, 0x05 };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
@@ -547,11 +625,13 @@ TEST(Decoder, ShouldDecodeArray_WhenMultiLevelIndefiniteArrarGiven4) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenInfiniteLengthGiven) {
+TEST(Decoder, ShouldDecodeArray_WhenInfiniteLengthGiven)
+{
 	// [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-	uint8_t m[] = { 0x9f,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,
-		0x0b,0x0c,0x0d,0x0e,0x0f,0x10,0x11,0x12,0x13,0x14,0x15,0x16,
-		0x17,0x18,0x18,0x18,0x19,0xff };
+	uint8_t m[] = { 0x9f, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x18, 0x18, 0x19, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -566,9 +646,11 @@ TEST(Decoder, ShouldDecodeArray_WhenInfiniteLengthGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeMap_WhenMultiInfiniteLengthGiven) {
+TEST(Decoder, ShouldDecodeMap_WhenMultiInfiniteLengthGiven)
+{
 	// {"a": 1, "b": [2, 3]}
-	uint8_t m[] = { 0xbf,0x61,0x61,0x01,0x61,0x62,0x9f,0x02,0x03,0xff,0xff };
+	uint8_t m[] = { 0xbf, 0x61, 0x61, 0x01, 0x61, 0x62,
+			0x9f, 0x02, 0x03, 0xff, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -587,9 +669,10 @@ TEST(Decoder, ShouldDecodeMap_WhenMultiInfiniteLengthGiven) {
 		check_item_type[items[i].type](items[i].size);
 	}
 }
-TEST(Decoder, ShouldDecodeArray_WhenInfiniteMapIncluded) {
+TEST(Decoder, ShouldDecodeArray_WhenInfiniteMapIncluded)
+{
 	// ["a", {"b": "c"}]
-	uint8_t m[] = { 0x82,0x61,0x61,0xbf,0x61,0x62,0x61,0x63,0xff };
+	uint8_t m[] = { 0x82, 0x61, 0x61, 0xbf, 0x61, 0x62, 0x61, 0x63, 0xff };
 	size_t n;
 
 	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, m, sizeof(m), &n));
@@ -607,8 +690,9 @@ TEST(Decoder, ShouldDecodeArray_WhenInfiniteMapIncluded) {
 	}
 }
 
-TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven) {
-	uint8_t m[] = { 0xfa,0x47,0xc3,0x50,0x00 };
+TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven)
+{
+	uint8_t m[] = { 0xfa, 0x47, 0xc3, 0x50, 0x00 };
 	size_t n;
 	float v;
 
@@ -624,8 +708,9 @@ TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	DOUBLES_EQUAL(100000.0, (double)v, 0.1);
 }
-TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven2) {
-	uint8_t m[] = { 0xfa,0x7f,0x7f,0xff,0xff };
+TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven2)
+{
+	uint8_t m[] = { 0xfa, 0x7f, 0x7f, 0xff, 0xff };
 	size_t n;
 	float v;
 
@@ -641,8 +726,9 @@ TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionGiven2) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	DOUBLES_EQUAL(3.4028234663852886e+38, (double)v, 0.1);
 }
-TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionInfinityGiven) {
-	uint8_t m[] = { 0xfa,0x7f,0x80,0x00,0x00 };
+TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionInfinityGiven)
+{
+	uint8_t m[] = { 0xfa, 0x7f, 0x80, 0x00, 0x00 };
 	size_t n;
 	float v;
 
@@ -658,8 +744,9 @@ TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionInfinityGiven) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	DOUBLES_EQUAL((double)INFINITY, (double)v, 0.1);
 }
-TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNegativeInfinityGiven) {
-	uint8_t m[] = { 0xfa,0xff,0x80,0x00,0x00 };
+TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNegativeInfinityGiven)
+{
+	uint8_t m[] = { 0xfa, 0xff, 0x80, 0x00, 0x00 };
 	size_t n;
 	float v;
 
@@ -675,8 +762,9 @@ TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNegativeInfinityGiven) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	DOUBLES_EQUAL((double)-INFINITY, (double)v, 0.1);
 }
-TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNanGiven) {
-	uint8_t m[] = {	0xfa,0x7f,0xc0,0x00,0x00 };
+TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNanGiven)
+{
+	uint8_t m[] = { 0xfa, 0x7f, 0xc0, 0x00, 0x00 };
 	size_t n;
 	float v;
 
@@ -693,8 +781,9 @@ TEST(Decoder, ShouldDecodeFloat_WhenSinglePrecisionNanGiven) {
 	CHECK(isnan(v) == true);
 }
 
-TEST(Decoder, ShouldDecodeFalse) {
-	uint8_t m[] = {	0xf4 };
+TEST(Decoder, ShouldDecodeFalse)
+{
+	uint8_t m[] = { 0xf4 };
 	size_t n;
 	uint8_t v;
 
@@ -710,8 +799,9 @@ TEST(Decoder, ShouldDecodeFalse) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	LONGS_EQUAL(0, v);
 }
-TEST(Decoder, ShouldDecodeTrue) {
-	uint8_t m[] = {	0xf5 };
+TEST(Decoder, ShouldDecodeTrue)
+{
+	uint8_t m[] = { 0xf5 };
 	size_t n;
 	uint8_t v;
 
@@ -727,8 +817,9 @@ TEST(Decoder, ShouldDecodeTrue) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	LONGS_EQUAL(1, v);
 }
-TEST(Decoder, ShouldDecodeNull) {
-	uint8_t m[] = {	0xf6 };
+TEST(Decoder, ShouldDecodeNull)
+{
+	uint8_t m[] = { 0xf6 };
 	size_t n;
 	uint8_t v;
 
@@ -744,8 +835,9 @@ TEST(Decoder, ShouldDecodeNull) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	LONGS_EQUAL(0, v);
 }
-TEST(Decoder, ShouldDecodeSimpleValue) {
-	uint8_t m[] = {	0xf0 };
+TEST(Decoder, ShouldDecodeSimpleValue)
+{
+	uint8_t m[] = { 0xf0 };
 	size_t n;
 	uint8_t v;
 
@@ -761,8 +853,9 @@ TEST(Decoder, ShouldDecodeSimpleValue) {
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, items, &v, sizeof(v)));
 	LONGS_EQUAL(16, v);
 }
-TEST(Decoder, ShouldDecodeSimpleValue_WhenFollowingByteGiven) {
-	uint8_t m[] = {	0xf8, 0xff };
+TEST(Decoder, ShouldDecodeSimpleValue_WhenFollowingByteGiven)
+{
+	uint8_t m[] = { 0xf8, 0xff };
 	size_t n;
 	uint8_t v;
 
@@ -779,49 +872,65 @@ TEST(Decoder, ShouldDecodeSimpleValue_WhenFollowingByteGiven) {
 	LONGS_EQUAL(255, v);
 }
 
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteUnsignedIntegerGiven) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteUnsignedIntegerGiven)
+{
 	for (uint8_t i = 0x18; i < 0x20; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteNegativeIntegerGiven) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteNegativeIntegerGiven)
+{
 	for (uint8_t i = 0x38; i < 0x40; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteStringGiven) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteStringGiven)
+{
 	for (uint8_t i = 0x41; i < 0x5f; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteArrayGiven) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteArrayGiven)
+{
 	for (uint8_t i = 0x81; i < 0x98; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteArrayGiven2) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteArrayGiven2)
+{
 	for (uint8_t i = 0x98; i < 0x9f; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteMapGiven) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteMapGiven)
+{
 	for (uint8_t i = 0xa1; i < 0xb8; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
-TEST(Decoder, ShouldReturnIllegal_WhenIncompleteMapGiven2) {
+TEST(Decoder, ShouldReturnIllegal_WhenIncompleteMapGiven2)
+{
 	for (uint8_t i = 0xb8; i < 0xbf; i++) {
-		LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, &i, sizeof(i), 0));
+		LONGS_EQUAL(CBOR_ILLEGAL,
+			    cbor_parse(&reader, &i, sizeof(i), 0));
 	}
 }
 
-TEST(Decoder, ShouldCleanBufferFirstBeforeUsed_WhenGabageGiven) {
+TEST(Decoder, ShouldCleanBufferFirstBeforeUsed_WhenGabageGiven)
+{
 	uint8_t m[] = { 0xa1, 0x61, 0x77, 0x0a };
 	size_t n;
 	uint32_t t = 0x12345678;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, m, sizeof(m), &n));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_decode(&reader, &items[2], &t, sizeof(t)));
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[2], &t, sizeof(t)));
 	LONGS_EQUAL(10, t);
 }
 

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -144,7 +144,8 @@ TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelIndefiniteContainer)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(4, n);
-	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(4, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
 	LONGS_EQUAL(2, scalar_count);
 }
 
@@ -156,7 +157,8 @@ TEST(Helper, iterate_ShouldHandleNestedIndefiniteContainerAndSibling)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(5, n);
-	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(5, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
 	LONGS_EQUAL(2, scalar_count);
 }
 
@@ -168,6 +170,173 @@ TEST(Helper, iterate_ShouldKeepSiblingAfterIndefiniteStringInContainer)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(5, n);
-	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(5, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
 	LONGS_EQUAL(3, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelDefiniteArray)
+{
+	/* array(1)[1] followed by sibling integer 2 */
+	uint8_t msg[] = { 0x81, 0x01, 0x02 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(3, n);
+	LONGS_EQUAL(3, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(2, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelDefiniteMap)
+{
+	/* map(1){"a":"b"} followed by sibling integer 2 */
+	uint8_t msg[] = { 0xa1, 0x61, 0x61, 0x61, 0x62, 0x02 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+	LONGS_EQUAL(4, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(3, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldVisitNoItems_WhenDefiniteArrayIsEmpty)
+{
+	/* array(0) = [] */
+	uint8_t msg[] = { 0x80 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(1, n);
+	LONGS_EQUAL(1, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(0, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldVisitNoItems_WhenDefiniteMapIsEmpty)
+{
+	/* map(0) = {} */
+	uint8_t msg[] = { 0xa0 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(1, n);
+	LONGS_EQUAL(1, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(0, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldVisitItemsInIndefiniteMap)
+{
+	/*
+	 * {_ "a": "b"} as a top-level indefinite map.
+	 * cbor_parse returns CBOR_BREAK because the message ends with 0xff;
+	 * this is the expected, correct return for a top-level indefinite
+	 * container that has no trailing sibling items.
+	 * cbor_iterate must still visit both key and value.
+	 */
+	uint8_t msg[] = { 0xbf, 0x61, 0x61, 0x61, 0x62, 0xff };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+	LONGS_EQUAL(4, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(2, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelIndefiniteMap)
+{
+	/* {_ "a": "b"} followed by sibling integer 1 */
+	uint8_t msg[] = { 0xbf, 0x61, 0x61, 0x61, 0x62, 0xff, 0x01 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(5, n);
+	LONGS_EQUAL(5, cbor_iterate(&reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(3, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldStopIteration_WhenMapSizeWouldOverflow)
+{
+	/*
+	 * SIZE_MAX == (size_t)CBOR_INDEFINITE_VALUE, so the overflow guard
+	 * applies to sizes in (SIZE_MAX/2, SIZE_MAX).  Use SIZE_MAX/2+1 as the
+	 * minimum value that crosses the boundary.
+	 */
+	cbor_item_t crafted_items[3];
+	cbor_reader_t crafted_reader;
+	uint8_t dummy[4] = { 0 };
+
+	cbor_reader_init(&crafted_reader, crafted_items,
+			 std::size(crafted_items));
+	crafted_reader.msg = dummy;
+	crafted_reader.msgsize = sizeof(dummy);
+	crafted_reader.itemidx = 3;
+
+	crafted_items[0] = { CBOR_ITEM_MAP,     0, SIZE_MAX / 2 + 1 };
+	crafted_items[1] = { CBOR_ITEM_INTEGER, 1, 1 };
+	crafted_items[2] = { CBOR_ITEM_INTEGER, 2, 1 };
+
+	size_t scalar_count = 0;
+	LONGS_EQUAL(0, cbor_iterate(&crafted_reader, nullptr, count_scalar_item,
+				    &scalar_count));
+	LONGS_EQUAL(0, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldNotStopIteration_WhenMapSizeIsAtOverflowBoundary)
+{
+	/*
+	 * SIZE_MAX/2 is the last value that does NOT trigger the guard:
+	 * size*2 == SIZE_MAX-1, which does not overflow.
+	 *
+	 * With only 1 remaining node, the MAP recursion visits crafted_items[1]
+	 * as the MAP's first declared child (capped by remaining_nodes=1), then
+	 * returns.  scalar_count==1 proves stop_iteration was NOT set and the
+	 * callback was reached — unlike the overflow case where count stays 0.
+	 */
+	cbor_item_t crafted_items[2];
+	cbor_reader_t crafted_reader;
+	uint8_t dummy[4] = { 0 };
+
+	cbor_reader_init(&crafted_reader, crafted_items,
+			 std::size(crafted_items));
+	crafted_reader.msg = dummy;
+	crafted_reader.msgsize = sizeof(dummy);
+	crafted_reader.itemidx = 2;
+
+	crafted_items[0] = { CBOR_ITEM_MAP,     0, SIZE_MAX / 2 };
+	crafted_items[1] = { CBOR_ITEM_INTEGER, 0, 0 };
+
+	size_t scalar_count = 0;
+	cbor_iterate(&crafted_reader, nullptr, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(1, scalar_count);
+}
+
+TEST(Helper, unmarshal_ShouldInvokeCallbacks_WhenIndefiniteMapGiven)
+{
+	/* {_ "certificate": "your-cert", "privateKey": "your-private-key"} */
+	uint8_t msg[] = {
+		0xBF, 0x6B, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69,
+		0x63, 0x61, 0x74, 0x65, 0x69, 0x79, 0x6F, 0x75, 0x72,
+		0x2D, 0x63, 0x65, 0x72, 0x74, 0x6A, 0x70, 0x72, 0x69,
+		0x76, 0x61, 0x74, 0x65, 0x4B, 0x65, 0x79, 0x70, 0x79,
+		0x6F, 0x75, 0x72, 0x2D, 0x70, 0x72, 0x69, 0x76, 0x61,
+		0x74, 0x65, 0x2D, 0x6B, 0x65, 0x79, 0xFF,
+	};
+
+	mock().expectOneCall("parse_cert");
+	mock().expectOneCall("parse_key");
+
+	LONGS_EQUAL(true, cbor_unmarshal(&reader, parsers,
+					 sizeof(parsers) / sizeof(*parsers),
+					 msg, sizeof(msg), nullptr));
 }

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -11,98 +11,139 @@
 #include "cbor/cbor.h"
 
 static void parse_cert(const cbor_reader_t *reader,
-		const struct cbor_parser *parser,
-		const cbor_item_t *item, void *arg) {
+		       const struct cbor_parser *parser,
+		       const cbor_item_t *item, void *arg)
+{
 	mock().actualCall(__func__);
 }
 
 static void parse_key(const cbor_reader_t *reader,
-		const struct cbor_parser *parser,
-		const cbor_item_t *item, void *arg) {
+		      const struct cbor_parser *parser, const cbor_item_t *item,
+		      void *arg)
+{
 	mock().actualCall(__func__);
 }
 
 static void parse_strkey(const cbor_reader_t *reader,
-		const struct cbor_parser *parser,
-		const cbor_item_t *item, void *arg) {
+			 const struct cbor_parser *parser,
+			 const cbor_item_t *item, void *arg)
+{
 	mock().actualCall(__func__);
 }
 
 static void parse_intkey(const cbor_reader_t *reader,
-		const struct cbor_parser *parser,
-		const cbor_item_t *item, void *arg) {
+			 const struct cbor_parser *parser,
+			 const cbor_item_t *item, void *arg)
+{
 	mock().actualCall(__func__);
 }
 
 static const struct cbor_parser parsers[] = {
 	{ .key = "certificate", .keylen = 11, .run = parse_cert },
-	{ .key = "privateKey",  .keylen = 10, .run = parse_key},
-	{ .key = "strkey1",     .keylen = 7,  .run = parse_strkey },
-	{ .key = (const void *)1,             .run = parse_intkey },
-	{ .key = "strkey2",     .keylen = 7,  .run = parse_strkey },
-	{ .key = (const void *)2,             .run = parse_intkey },
+	{ .key = "privateKey", .keylen = 10, .run = parse_key },
+	{ .key = "strkey1", .keylen = 7, .run = parse_strkey },
+	{ .key = (const void *)1, .run = parse_intkey },
+	{ .key = "strkey2", .keylen = 7, .run = parse_strkey },
+	{ .key = (const void *)2, .run = parse_intkey },
 };
 
-TEST_GROUP(Helper) {
+static void count_scalar_item(const cbor_reader_t *reader,
+			      const cbor_item_t *item,
+			      const cbor_item_t *parent, void *arg)
+{
+	(void)reader;
+	(void)item;
+	(void)parent;
+
+	size_t *count = (size_t *)arg;
+	(*count)++;
+}
+
+TEST_GROUP(Helper)
+{
 	cbor_reader_t reader;
 	cbor_item_t items[256];
 
-	void setup(void) {
-		cbor_reader_init(&reader, items, sizeof(items)/sizeof(*items));
+	void setup(void)
+	{
+		cbor_reader_init(&reader, items,
+				 sizeof(items) / sizeof(*items));
 	}
-	void teardown(void) {
+	void teardown(void)
+	{
 		mock().checkExpectations();
 		mock().clear();
 	}
 };
 
-TEST(Helper, unmarshal_ShouldReturnTrue_WhenSucceed) {
+TEST(Helper, unmarshal_ShouldReturnTrue_WhenSucceed)
+{
 	// {"certificate": "your-cert", "privateKey": "your-private-key" }
-	uint8_t msg[] = {
-		0xA2, 0x6B, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66,
-		0x69, 0x63, 0x61, 0x74, 0x65, 0x69, 0x79, 0x6F,
-		0x75, 0x72, 0x2D, 0x63, 0x65, 0x72, 0x74, 0x6A,
-		0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x4B,
-		0x65, 0x79, 0x70, 0x79, 0x6F, 0x75, 0x72, 0x2D,
-		0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x2D,
-		0x6B, 0x65, 0x79
-	};
+	uint8_t msg[] = { 0xA2, 0x6B, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69,
+			  0x63, 0x61, 0x74, 0x65, 0x69, 0x79, 0x6F, 0x75, 0x72,
+			  0x2D, 0x63, 0x65, 0x72, 0x74, 0x6A, 0x70, 0x72, 0x69,
+			  0x76, 0x61, 0x74, 0x65, 0x4B, 0x65, 0x79, 0x70, 0x79,
+			  0x6F, 0x75, 0x72, 0x2D, 0x70, 0x72, 0x69, 0x76, 0x61,
+			  0x74, 0x65, 0x2D, 0x6B, 0x65, 0x79 };
 
 	mock().expectOneCall("parse_cert");
 	mock().expectOneCall("parse_key");
 
 	cbor_unmarshal(&reader, parsers, sizeof(parsers) / sizeof(*parsers),
-			msg, sizeof(msg), 0);
+		       msg, sizeof(msg), 0);
 }
 
-TEST(Helper, unmarshal_ShouldReturnFalse_WhenInvalidMessageGiven) {
-	uint8_t msg[] = {
-		0xA2, 0x6B, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66,
-		0x69, 0x63, 0x61, 0x74, 0x65, 0x69, 0x79, 0x6F,
-		0x75, 0x72, 0x2D, 0x63, 0x65, 0x72, 0x74, 0x6A,
-		0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x4B,
-		0x65, 0x79, 0x70, 0x79, 0x6F, 0x75, 0x72, 0x2D,
-		0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x2D,
-		0x6B, 0x65
-	};
+TEST(Helper, unmarshal_ShouldReturnFalse_WhenInvalidMessageGiven)
+{
+	uint8_t msg[] = { 0xA2, 0x6B, 0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69,
+			  0x63, 0x61, 0x74, 0x65, 0x69, 0x79, 0x6F, 0x75, 0x72,
+			  0x2D, 0x63, 0x65, 0x72, 0x74, 0x6A, 0x70, 0x72, 0x69,
+			  0x76, 0x61, 0x74, 0x65, 0x4B, 0x65, 0x79, 0x70, 0x79,
+			  0x6F, 0x75, 0x72, 0x2D, 0x70, 0x72, 0x69, 0x76, 0x61,
+			  0x74, 0x65, 0x2D, 0x6B, 0x65 };
 
 	LONGS_EQUAL(false, cbor_unmarshal(&reader, parsers,
-			sizeof(parsers) / sizeof(*parsers),
-			msg, sizeof(msg), 0));
+					  sizeof(parsers) / sizeof(*parsers),
+					  msg, sizeof(msg), 0));
 }
 
-TEST(Helper, ShouldUnmarshal_WhenBothOfStrKeyAndIntKeyGiven) {
+TEST(Helper, ShouldUnmarshal_WhenBothOfStrKeyAndIntKeyGiven)
+{
 	uint8_t msg[] = {
-		0xA4, 0x01, 0x66, 0x69, 0x6E, 0x74, 0x6B, 0x65, 
-		0x79, 0x67, 0x73, 0x74, 0x72, 0x6B, 0x65, 0x79, 
-		0x32, 0x63, 0x61, 0x62, 0x63, 0x02, 0x01, 0x67, 
-		0x73, 0x74, 0x72, 0x6B, 0x65, 0x79, 0x31, 0x02, 
+		0xA4, 0x01, 0x66, 0x69, 0x6E, 0x74, 0x6B, 0x65,
+		0x79, 0x67, 0x73, 0x74, 0x72, 0x6B, 0x65, 0x79,
+		0x32, 0x63, 0x61, 0x62, 0x63, 0x02, 0x01, 0x67,
+		0x73, 0x74, 0x72, 0x6B, 0x65, 0x79, 0x31, 0x02,
 	};
 
 	mock().expectNCalls(2, "parse_intkey");
 	mock().expectNCalls(2, "parse_strkey");
 
 	LONGS_EQUAL(true, cbor_unmarshal(&reader, parsers,
-			sizeof(parsers) / sizeof(*parsers),
-			msg, sizeof(msg), 0));
+					 sizeof(parsers) / sizeof(*parsers),
+					 msg, sizeof(msg), 0));
+}
+
+TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelIndefiniteContainer)
+{
+	uint8_t msg[] = { 0x9f, 0x01, 0xff, 0x02 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(2, scalar_count);
+}
+
+TEST(Helper, iterate_ShouldHandleNestedIndefiniteContainerAndSibling)
+{
+	uint8_t msg[] = { 0x82, 0x9f, 0x01, 0xff, 0x02 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(5, n);
+	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(2, scalar_count);
 }

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -10,8 +10,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <iterator>
-
 #include "cbor/cbor.h"
 
 static const char *get_mock_name(const struct cbor_parser *parser)
@@ -79,7 +77,7 @@ TEST_GROUP(Helper)
 
 	void setup(void)
 	{
-		cbor_reader_init(&reader, items, std::size(items));
+		cbor_reader_init(&reader, items, sizeof(items) / sizeof(items[0]));
 	}
 	void teardown(void)
 	{
@@ -277,7 +275,7 @@ TEST(Helper, iterate_ShouldStopIteration_WhenMapSizeWouldOverflow)
 	uint8_t dummy[4] = { 0 };
 
 	cbor_reader_init(&crafted_reader, crafted_items,
-			 std::size(crafted_items));
+			 sizeof(crafted_items) / sizeof(crafted_items[0]));
 	crafted_reader.msg = dummy;
 	crafted_reader.msgsize = sizeof(dummy);
 	crafted_reader.itemidx = 3;
@@ -308,7 +306,7 @@ TEST(Helper, iterate_ShouldNotStopIteration_WhenMapSizeIsAtOverflowBoundary)
 	uint8_t dummy[4] = { 0 };
 
 	cbor_reader_init(&crafted_reader, crafted_items,
-			 std::size(crafted_items));
+			 sizeof(crafted_items) / sizeof(crafted_items[0]));
 	crafted_reader.msg = dummy;
 	crafted_reader.msgsize = sizeof(dummy);
 	crafted_reader.itemidx = 2;

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -147,3 +147,15 @@ TEST(Helper, iterate_ShouldHandleNestedIndefiniteContainerAndSibling)
 	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
 	LONGS_EQUAL(2, scalar_count);
 }
+
+TEST(Helper, iterate_ShouldKeepSiblingAfterIndefiniteStringInContainer)
+{
+	uint8_t msg[] = { 0x82, 0x7f, 0x61, 0x61, 0xff, 0x02 };
+	size_t n = 0;
+	size_t scalar_count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(5, n);
+	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	LONGS_EQUAL(3, scalar_count);
+}

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -8,43 +8,56 @@
 #include "CppUTest/TestHarness_c.h"
 #include "CppUTestExt/MockSupport.h"
 
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+
 #include "cbor/cbor.h"
 
-static void parse_cert(const cbor_reader_t *reader,
+static const char *get_mock_name(const struct cbor_parser *parser)
+{
+	if (parser->keylen == 11 &&
+	    std::memcmp(parser->key, "certificate", parser->keylen) == 0) {
+		return "parse_cert";
+	}
+
+	if (parser->keylen == 10 &&
+	    std::memcmp(parser->key, "privateKey", parser->keylen) == 0) {
+		return "parse_key";
+	}
+
+	if (parser->keylen == 7 &&
+	    (std::memcmp(parser->key, "strkey1", parser->keylen) == 0 ||
+	     std::memcmp(parser->key, "strkey2", parser->keylen) == 0)) {
+		return "parse_strkey";
+	}
+
+	if ((std::intptr_t)parser->key == 1 ||
+	    (std::intptr_t)parser->key == 2) {
+		return "parse_intkey";
+	}
+
+	return "parse_unknown";
+}
+
+static void parse_item(const cbor_reader_t *reader,
 		       const struct cbor_parser *parser,
 		       const cbor_item_t *item, void *arg)
 {
-	mock().actualCall(__func__);
-}
+	(void)reader;
+	(void)item;
+	(void)arg;
 
-static void parse_key(const cbor_reader_t *reader,
-		      const struct cbor_parser *parser, const cbor_item_t *item,
-		      void *arg)
-{
-	mock().actualCall(__func__);
-}
-
-static void parse_strkey(const cbor_reader_t *reader,
-			 const struct cbor_parser *parser,
-			 const cbor_item_t *item, void *arg)
-{
-	mock().actualCall(__func__);
-}
-
-static void parse_intkey(const cbor_reader_t *reader,
-			 const struct cbor_parser *parser,
-			 const cbor_item_t *item, void *arg)
-{
-	mock().actualCall(__func__);
+	mock().actualCall(get_mock_name(parser));
 }
 
 static const struct cbor_parser parsers[] = {
-	{ .key = "certificate", .keylen = 11, .run = parse_cert },
-	{ .key = "privateKey", .keylen = 10, .run = parse_key },
-	{ .key = "strkey1", .keylen = 7, .run = parse_strkey },
-	{ .key = (const void *)1, .run = parse_intkey },
-	{ .key = "strkey2", .keylen = 7, .run = parse_strkey },
-	{ .key = (const void *)2, .run = parse_intkey },
+	{ .key = "certificate", .keylen = 11, .run = parse_item },
+	{ .key = "privateKey", .keylen = 10, .run = parse_item },
+	{ .key = "strkey1", .keylen = 7, .run = parse_item },
+	{ .key = (const void *)1, .run = parse_item },
+	{ .key = "strkey2", .keylen = 7, .run = parse_item },
+	{ .key = (const void *)2, .run = parse_item },
 };
 
 static void count_scalar_item(const cbor_reader_t *reader,
@@ -55,7 +68,7 @@ static void count_scalar_item(const cbor_reader_t *reader,
 	(void)item;
 	(void)parent;
 
-	size_t *count = (size_t *)arg;
+	auto *count = static_cast<size_t *>(arg);
 	(*count)++;
 }
 
@@ -66,8 +79,7 @@ TEST_GROUP(Helper)
 
 	void setup(void)
 	{
-		cbor_reader_init(&reader, items,
-				 sizeof(items) / sizeof(*items));
+		cbor_reader_init(&reader, items, std::size(items));
 	}
 	void teardown(void)
 	{
@@ -90,7 +102,7 @@ TEST(Helper, unmarshal_ShouldReturnTrue_WhenSucceed)
 	mock().expectOneCall("parse_key");
 
 	cbor_unmarshal(&reader, parsers, sizeof(parsers) / sizeof(*parsers),
-		       msg, sizeof(msg), 0);
+		       msg, sizeof(msg), nullptr);
 }
 
 TEST(Helper, unmarshal_ShouldReturnFalse_WhenInvalidMessageGiven)
@@ -104,7 +116,7 @@ TEST(Helper, unmarshal_ShouldReturnFalse_WhenInvalidMessageGiven)
 
 	LONGS_EQUAL(false, cbor_unmarshal(&reader, parsers,
 					  sizeof(parsers) / sizeof(*parsers),
-					  msg, sizeof(msg), 0));
+					  msg, sizeof(msg), nullptr));
 }
 
 TEST(Helper, ShouldUnmarshal_WhenBothOfStrKeyAndIntKeyGiven)
@@ -121,7 +133,7 @@ TEST(Helper, ShouldUnmarshal_WhenBothOfStrKeyAndIntKeyGiven)
 
 	LONGS_EQUAL(true, cbor_unmarshal(&reader, parsers,
 					 sizeof(parsers) / sizeof(*parsers),
-					 msg, sizeof(msg), 0));
+					 msg, sizeof(msg), nullptr));
 }
 
 TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelIndefiniteContainer)
@@ -132,7 +144,7 @@ TEST(Helper, iterate_ShouldKeepSiblingAfterTopLevelIndefiniteContainer)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(4, n);
-	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
 	LONGS_EQUAL(2, scalar_count);
 }
 
@@ -144,7 +156,7 @@ TEST(Helper, iterate_ShouldHandleNestedIndefiniteContainerAndSibling)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(5, n);
-	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
 	LONGS_EQUAL(2, scalar_count);
 }
 
@@ -156,6 +168,6 @@ TEST(Helper, iterate_ShouldKeepSiblingAfterIndefiniteStringInContainer)
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
 	LONGS_EQUAL(5, n);
-	(void)cbor_iterate(&reader, NULL, count_scalar_item, &scalar_count);
+	(void)cbor_iterate(&reader, nullptr, count_scalar_item, &scalar_count);
 	LONGS_EQUAL(3, scalar_count);
 }

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -74,3 +74,41 @@ TEST(ParserCount, ShouldReturnIllegal_WhenIndefiniteArrayMissingBreak)
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
 	LONGS_EQUAL(2, n);
 }
+
+TEST(ParserCount,
+     ShouldCountNestedIndefiniteString_WhenSiblingItemFollowsInContainer)
+{
+	uint8_t msg[] = { 0x82, 0x7f, 0x61, 0x61, 0x61, 0x62, 0xff, 0x01 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(6, n);
+}
+
+TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteStringExceedsItemBuffer)
+{
+	uint8_t msg[] = { 0x7f, 0x61, 0x61, 0xff };
+	cbor_reader_t limited_reader;
+	cbor_item_t limited_items[2];
+	size_t parsed = 0;
+
+	cbor_reader_init(&limited_reader, limited_items,
+			 sizeof(limited_items) / sizeof(*limited_items));
+	LONGS_EQUAL(CBOR_OVERRUN,
+		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+}
+
+TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteArrayExceedsItemBuffer)
+{
+	uint8_t msg[] = { 0x9f, 0x01, 0xff };
+	cbor_reader_t limited_reader;
+	cbor_item_t limited_items[2];
+	size_t parsed = 0;
+
+	cbor_reader_init(&limited_reader, limited_items,
+			 sizeof(limited_items) / sizeof(*limited_items));
+	LONGS_EQUAL(CBOR_OVERRUN,
+		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -99,6 +99,21 @@ TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteStringExceedsItemBuffer)
 	LONGS_EQUAL(2, parsed);
 }
 
+TEST(ParserCount,
+	     ShouldReturnIllegal_WhenIndefiniteStringMissingBreakAtEndOfFullItemBuffer)
+{
+	uint8_t msg[] = { 0x7f, 0x61, 0x61 };
+	cbor_reader_t limited_reader;
+	cbor_item_t limited_items[2];
+	size_t parsed = 0;
+
+	cbor_reader_init(&limited_reader, limited_items,
+			 sizeof(limited_items) / sizeof(*limited_items));
+	LONGS_EQUAL(CBOR_ILLEGAL,
+		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+}
+
 TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteArrayExceedsItemBuffer)
 {
 	uint8_t msg[] = { 0x9f, 0x01, 0xff };
@@ -109,6 +124,36 @@ TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteArrayExceedsItemBuffer)
 	cbor_reader_init(&limited_reader, limited_items,
 			 sizeof(limited_items) / sizeof(*limited_items));
 	LONGS_EQUAL(CBOR_OVERRUN,
+		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+}
+
+TEST(ParserCount,
+	     ShouldReturnIllegal_WhenIndefiniteArrayMissingBreakAtEndOfFullItemBuffer)
+{
+	uint8_t msg[] = { 0x9f, 0x01 };
+	cbor_reader_t limited_reader;
+	cbor_item_t limited_items[2];
+	size_t parsed = 0;
+
+	cbor_reader_init(&limited_reader, limited_items,
+			 sizeof(limited_items) / sizeof(*limited_items));
+	LONGS_EQUAL(CBOR_ILLEGAL,
+		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+}
+
+TEST(ParserCount,
+	     ShouldReturnIllegal_WhenDefiniteArrayTruncatedAtEndOfFullItemBuffer)
+{
+	uint8_t msg[] = { 0x82, 0x01 };
+	cbor_reader_t limited_reader;
+	cbor_item_t limited_items[2];
+	size_t parsed = 0;
+
+	cbor_reader_init(&limited_reader, limited_items,
+			 sizeof(limited_items) / sizeof(*limited_items));
+	LONGS_EQUAL(CBOR_ILLEGAL,
 		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
 	LONGS_EQUAL(2, parsed);
 }

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -244,3 +244,38 @@ TEST(ParserCount,
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
 	LONGS_EQUAL(6, n);
 }
+
+/* Regression tests: BREAK byte inside a definite-length container must be
+ * treated as CBOR_ILLEGAL, not propagated as CBOR_BREAK to the caller. */
+
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenDefiniteArrayContainsBreakByte)
+{
+	/* [1] encoded as 0x81 but with 0xff (BREAK) as the sole item */
+	uint8_t msg[] = { 0x81, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[4];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}
+
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenDefiniteMapContainsBreakByte)
+{
+	/* {1: ?} encoded as 0xa1 but with 0xff (BREAK) as the first key */
+	uint8_t msg[] = { 0xa1, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[4];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -1,0 +1,40 @@
+#include "CppUTest/TestHarness.h"
+
+#include "cbor/parser.h"
+
+TEST_GROUP(ParserCount){};
+
+TEST(ParserCount, ShouldCountItemsWithoutBuffer_WhenValidMessageGiven)
+{
+	uint8_t msg[] = { 0xA2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x02 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(5, n);
+}
+
+TEST(ParserCount, ShouldCountItemsEvenWhenParseBufferWouldOverrun)
+{
+	uint8_t msg[] = { 0x84, 0x01, 0x02, 0x03, 0x04 };
+	cbor_reader_t reader;
+	cbor_item_t items[2];
+	size_t parsed = 0;
+	size_t counted = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_OVERRUN,
+		    cbor_parse(&reader, msg, sizeof(msg), &parsed));
+	LONGS_EQUAL(2, parsed);
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &counted));
+	LONGS_EQUAL(5, counted);
+}
+
+TEST(ParserCount, ShouldReturnIllegal_WhenMessageIsIncomplete)
+{
+	uint8_t msg[] = { 0x18 };
+	size_t n = 1234;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(0, n);
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -184,10 +184,8 @@ TEST(ParserCount,
 	 *   02          -- value 2
 	 *   ff          -- BREAK (outer map)
 	 */
-	uint8_t msg[] = {
-		0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01, 0xff,
-		0x61, 0x62, 0x02, 0xff
-	};
+	uint8_t msg[] = { 0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01,
+			  0xff, 0x61, 0x62, 0x02, 0xff };
 	cbor_reader_t reader;
 	cbor_item_t items[16];
 	size_t n = 0;
@@ -202,10 +200,8 @@ TEST(ParserCount,
      ShouldCountSuccessfully_WhenIndefiniteMapContainsIndefiniteByteString)
 {
 	/* {_ "a" h'01'(indef) "b" 2 } */
-	uint8_t msg[] = {
-		0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01, 0xff,
-		0x61, 0x62, 0x02, 0xff
-	};
+	uint8_t msg[] = { 0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01,
+			  0xff, 0x61, 0x62, 0x02, 0xff };
 	size_t n = 0;
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
@@ -248,8 +244,7 @@ TEST(ParserCount,
 /* Regression tests: BREAK byte inside a definite-length container must be
  * treated as CBOR_ILLEGAL, not propagated as CBOR_BREAK to the caller. */
 
-TEST(ParserCount,
-     ShouldReturnIllegal_WhenDefiniteArrayContainsBreakByte)
+TEST(ParserCount, ShouldReturnIllegal_WhenDefiniteArrayContainsBreakByte)
 {
 	/* [1] encoded as 0x81 but with 0xff (BREAK) as the sole item */
 	uint8_t msg[] = { 0x81, 0xff };
@@ -264,13 +259,41 @@ TEST(ParserCount,
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
 }
 
-TEST(ParserCount,
-     ShouldReturnIllegal_WhenDefiniteMapContainsBreakByte)
+TEST(ParserCount, ShouldReturnIllegal_WhenDefiniteMapContainsBreakByte)
 {
 	/* {1: ?} encoded as 0xa1 but with 0xff (BREAK) as the first key */
 	uint8_t msg[] = { 0xa1, 0xff };
 	cbor_reader_t reader;
 	cbor_item_t items[4];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}
+
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenDefiniteArrayContainsBreakBeforeLastItem)
+{
+	uint8_t msg[] = { 0x82, 0xff, 0x01 };
+	cbor_reader_t reader;
+	cbor_item_t items[8];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}
+
+TEST(ParserCount, ShouldReturnIllegal_WhenTopLevelBreakHasTrailingItem)
+{
+	uint8_t msg[] = { 0xff, 0x01 };
+	cbor_reader_t reader;
+	cbor_item_t items[8];
 	size_t n = 0;
 
 	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -241,6 +241,21 @@ TEST(ParserCount,
 	LONGS_EQUAL(6, n);
 }
 
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenOuterIndefiniteArrayMissingBreakAfterNestedBreak)
+{
+	uint8_t msg[] = { 0x9f, 0x7f, 0x61, 0x61, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}
+
 /* Regression tests: BREAK byte inside a definite-length container must be
  * treated as CBOR_ILLEGAL, not propagated as CBOR_BREAK to the caller. */
 

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -132,3 +132,115 @@ TEST(ParserCount,
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
 	LONGS_EQUAL(4, n);
 }
+
+/* Regression tests: nested indefinite container BREAK must not terminate the
+ * outer indefinite container prematurely. */
+
+TEST(ParserCount,
+     ShouldParseSuccessfully_WhenIndefiniteArrayContainsIndefiniteTextString)
+{
+	/* [_ (_ "a") 2 ]
+	 * 9f         -- indefinite array
+	 *   7f       -- indefinite text string
+	 *     61 61  -- chunk "a"
+	 *     ff     -- BREAK (inner string)
+	 *   02       -- integer 2
+	 *   ff       -- BREAK (outer array)
+	 */
+	uint8_t msg[] = { 0x9f, 0x7f, 0x61, 0x61, 0xff, 0x02, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	/* cbor_parse returns CBOR_BREAK when the top-level container is
+	 * indefinite-length; inner indefinite strings must not terminate it
+	 * prematurely. */
+	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(6, n);
+}
+
+TEST(ParserCount,
+     ShouldCountSuccessfully_WhenIndefiniteArrayContainsIndefiniteTextString)
+{
+	/* [_ (_ "a") 2 ] */
+	uint8_t msg[] = { 0x9f, 0x7f, 0x61, 0x61, 0xff, 0x02, 0xff };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(6, n);
+}
+
+TEST(ParserCount,
+     ShouldParseSuccessfully_WhenIndefiniteMapContainsIndefiniteByteString)
+{
+	/* {_ "a" h'01'(indef) "b" 2 }
+	 * bf            -- indefinite map
+	 *   61 61       -- key "a"
+	 *   5f          -- indefinite byte string
+	 *     41 01     -- chunk h'01'
+	 *     ff        -- BREAK (inner byte string)
+	 *   61 62       -- key "b"
+	 *   02          -- value 2
+	 *   ff          -- BREAK (outer map)
+	 */
+	uint8_t msg[] = {
+		0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01, 0xff,
+		0x61, 0x62, 0x02, 0xff
+	};
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	/* cbor_parse returns CBOR_BREAK for indefinite-length top container. */
+	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(8, n);
+}
+
+TEST(ParserCount,
+     ShouldCountSuccessfully_WhenIndefiniteMapContainsIndefiniteByteString)
+{
+	/* {_ "a" h'01'(indef) "b" 2 } */
+	uint8_t msg[] = {
+		0xbf, 0x61, 0x61, 0x5f, 0x41, 0x01, 0xff,
+		0x61, 0x62, 0x02, 0xff
+	};
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(8, n);
+}
+
+TEST(ParserCount,
+     ShouldParseSuccessfully_WhenIndefiniteArrayContainsNestedIndefiniteArray)
+{
+	/* [_ [_ 1] 2 ]
+	 * 9f      -- outer indefinite array
+	 *   9f    -- inner indefinite array
+	 *     01  -- integer 1
+	 *     ff  -- BREAK (inner array)
+	 *   02    -- integer 2
+	 *   ff    -- BREAK (outer array)
+	 */
+	uint8_t msg[] = { 0x9f, 0x9f, 0x01, 0xff, 0x02, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	/* cbor_parse returns CBOR_BREAK for indefinite-length top container. */
+	LONGS_EQUAL(CBOR_BREAK, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(6, n);
+}
+
+TEST(ParserCount,
+     ShouldCountSuccessfully_WhenIndefiniteArrayContainsNestedIndefiniteArray)
+{
+	/* [_ [_ 1] 2 ] */
+	uint8_t msg[] = { 0x9f, 0x9f, 0x01, 0xff, 0x02, 0xff };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(6, n);
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -133,6 +133,46 @@ TEST(ParserCount,
 	LONGS_EQUAL(4, n);
 }
 
+TEST(ParserCount,
+	     ShouldParseSuccessfully_WhenDefiniteArrayContainsIndefiniteTextString)
+{
+	uint8_t msg[] = { 0x81, 0x7f, 0x61, 0x61, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}
+
+TEST(ParserCount,
+	     ShouldCountSuccessfully_WhenDefiniteArrayContainsIndefiniteTextString)
+{
+	uint8_t msg[] = { 0x81, 0x7f, 0x61, 0x61, 0xff };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}
+
+TEST(ParserCount,
+	     ShouldReturnIllegal_WhenDefiniteArrayIsMissingItemAfterIndefiniteTextString)
+{
+	uint8_t msg[] = { 0x82, 0x7f, 0x61, 0x61, 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[16];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}
+
 /* Regression tests: nested indefinite container BREAK must not terminate the
  * outer indefinite container prematurely. */
 

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -38,3 +38,39 @@ TEST(ParserCount, ShouldReturnIllegal_WhenMessageIsIncomplete)
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
 	LONGS_EQUAL(0, n);
 }
+
+TEST(ParserCount, ShouldContinueCountingAfterBreak_WhenMoreTopLevelItemsExist)
+{
+	uint8_t msg[] = { 0x9f, 0x01, 0xff, 0x02 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}
+
+TEST(ParserCount, ShouldReturnIllegal_WhenDefiniteArrayIsTruncated)
+{
+	uint8_t msg[] = { 0x82, 0x01 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+}
+
+TEST(ParserCount, ShouldReturnIllegal_WhenDefiniteMapIsTruncated)
+{
+	uint8_t msg[] = { 0xa1, 0x01 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+}
+
+TEST(ParserCount, ShouldReturnIllegal_WhenIndefiniteArrayMissingBreak)
+{
+	uint8_t msg[] = { 0x9f, 0x01 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -302,3 +302,19 @@ TEST(ParserCount, ShouldReturnIllegal_WhenTopLevelBreakHasTrailingItem)
 	n = 0;
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
 }
+
+/* Regression test: a standalone 0xff (BREAK with no enclosing indefinite
+ * container) is malformed CBOR and must not be reported as success. */
+TEST(ParserCount, ShouldReturnIllegal_WhenTopLevelBreakIsStandalone)
+{
+	uint8_t msg[] = { 0xff };
+	cbor_reader_t reader;
+	cbor_item_t items[8];
+	size_t n = 0;
+
+	cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+
+	n = 0;
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+}

--- a/tests/src/parser_count_test.cpp
+++ b/tests/src/parser_count_test.cpp
@@ -112,3 +112,23 @@ TEST(ParserCount, ShouldReturnOverrun_WhenIndefiniteArrayExceedsItemBuffer)
 		    cbor_parse(&limited_reader, msg, sizeof(msg), &parsed));
 	LONGS_EQUAL(2, parsed);
 }
+
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenDefiniteMapMissingValueAfterComplexKey)
+{
+	uint8_t msg[] = { 0xa1, 0x82, 0x01, 0x02 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}
+
+TEST(ParserCount,
+     ShouldReturnIllegal_WhenDefiniteArrayMissingItemAfterComplexElement)
+{
+	uint8_t msg[] = { 0x82, 0x82, 0x01, 0x02 };
+	size_t n = 0;
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_count_items(msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+}

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -1,7 +1,32 @@
 #include "CppUTest/TestHarness.h"
 
+#include <cstdlib>
 #include <cstdio>
 #include <string>
+
+#if !defined(CBOR_PROJECT_ROOT)
+#define CBOR_PROJECT_ROOT ".."
+#endif
+
+static std::string get_script_path(void)
+{
+	return std::string(CBOR_PROJECT_ROOT) + "/tools/cbor_item_count.py";
+}
+
+static bool can_run_item_count_tool(void)
+{
+	if (std::system("command -v python3 >/dev/null 2>&1") != 0) {
+		return false;
+	}
+
+	FILE *fp = std::fopen(get_script_path().c_str(), "r");
+	if (fp == NULL) {
+		return false;
+	}
+
+	std::fclose(fp);
+	return true;
+}
 
 static std::string run_command(const char *command)
 {
@@ -22,8 +47,13 @@ TEST_GROUP(ToolItemCount){};
 
 TEST(ToolItemCount, ShouldPrintSuccessForValidDefiniteMap)
 {
+	if (!can_run_item_count_tool()) {
+		return;
+	}
+
 	std::string out = run_command(
-		"python3 ../tools/cbor_item_count.py --hex \"A1 61 61 01\"");
+		("python3 \"" + get_script_path() + "\" --hex \"A1 61 61 01\"")
+			.c_str());
 
 	STRCMP_CONTAINS("error: CBOR_SUCCESS", out.c_str());
 	STRCMP_CONTAINS("items: 3", out.c_str());
@@ -31,8 +61,13 @@ TEST(ToolItemCount, ShouldPrintSuccessForValidDefiniteMap)
 
 TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
 {
+	if (!can_run_item_count_tool()) {
+		return;
+	}
+
 	std::string out = run_command(
-		"python3 ../tools/cbor_item_count.py --hex \"A1 61 61\"");
+		("python3 \"" + get_script_path() + "\" --hex \"A1 61 61\"")
+			.c_str());
 
 	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
 }

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -32,6 +32,17 @@ static bool can_run_item_count_tool(void)
 	return true;
 }
 
+static bool require_item_count_tool(void)
+{
+	if (can_run_item_count_tool()) {
+		return true;
+	}
+
+	CHECK_TEXT(false,
+			"python3 or tools/cbor_item_count.py is not available");
+	return false;
+}
+
 static std::string run_command(const char *command)
 {
 	std::string output;
@@ -52,7 +63,7 @@ TEST_GROUP(ToolItemCount){};
 
 TEST(ToolItemCount, ShouldPrintSuccessForValidDefiniteMap)
 {
-	if (!can_run_item_count_tool()) {
+	if (!require_item_count_tool()) {
 		return;
 	}
 
@@ -66,7 +77,7 @@ TEST(ToolItemCount, ShouldPrintSuccessForValidDefiniteMap)
 
 TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
 {
-	if (!can_run_item_count_tool()) {
+	if (!require_item_count_tool()) {
 		return;
 	}
 
@@ -80,7 +91,7 @@ TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
 TEST(ToolItemCount,
      ShouldPrintBreakWhenTopLevelIndefiniteArrayContainsNestedIndefiniteArray)
 {
-	if (!can_run_item_count_tool()) {
+	if (!require_item_count_tool()) {
 		return;
 	}
 
@@ -90,4 +101,43 @@ TEST(ToolItemCount,
 
 	STRCMP_CONTAINS("error: CBOR_BREAK", out.c_str());
 	STRCMP_CONTAINS("items: 6", out.c_str());
+}
+
+TEST(ToolItemCount, ShouldPrintIllegalForMissingBreakInIndefiniteString)
+{
+	if (!require_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(
+		("python3 \"" + get_script_path() + "\" --hex \"7f 61 61\"")
+			.c_str());
+
+	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
+}
+
+TEST(ToolItemCount, ShouldPrintIllegalForMissingBreakInIndefiniteArray)
+{
+	if (!require_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(
+		("python3 \"" + get_script_path() + "\" --hex \"9f 01\"")
+			.c_str());
+
+	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
+}
+
+TEST(ToolItemCount, ShouldPrintIllegalForMissingBreakInIndefiniteMap)
+{
+	if (!require_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(
+		("python3 \"" + get_script_path() + "\" --hex \"bf 61 61 01\"")
+			.c_str());
+
+	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
 }

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -2,7 +2,6 @@
 
 #include <array>
 #include <cstdlib>
-#include <cstdio>
 #include <stdio.h>
 #include <string>
 
@@ -23,12 +22,12 @@ static bool can_run_item_count_tool(void)
 		return false;
 	}
 
-	FILE *fp = std::fopen(get_script_path().c_str(), "r");
+	FILE *fp = fopen(get_script_path().c_str(), "r");
 	if (fp == nullptr) {
 		return false;
 	}
 
-	std::fclose(fp);
+	fclose(fp);
 	return true;
 }
 
@@ -38,8 +37,9 @@ static bool require_item_count_tool(void)
 		return true;
 	}
 
-	CHECK_TEXT(false,
-			"python3 or tools/cbor_item_count.py is not available");
+	fprintf(stderr,
+		"Skipping ToolItemCount tests: python3 or tools/cbor_item_count.py "
+		"is not available\n");
 	return false;
 }
 

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -1,0 +1,38 @@
+#include "CppUTest/TestHarness.h"
+
+#include <cstdio>
+#include <string>
+
+static std::string run_command(const char *command)
+{
+	std::string output;
+	char buffer[256];
+	FILE *pipe = popen(command, "r");
+
+	CHECK_TEXT(pipe != NULL, "popen failed");
+	while (fgets(buffer, (int)sizeof(buffer), pipe) != NULL) {
+		output += buffer;
+	}
+	pclose(pipe);
+
+	return output;
+}
+
+TEST_GROUP(ToolItemCount){};
+
+TEST(ToolItemCount, ShouldPrintSuccessForValidDefiniteMap)
+{
+	std::string out = run_command(
+		"python3 ../tools/cbor_item_count.py --hex \"A1 61 61 01\"");
+
+	STRCMP_CONTAINS("error: CBOR_SUCCESS", out.c_str());
+	STRCMP_CONTAINS("items: 3", out.c_str());
+}
+
+TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
+{
+	std::string out = run_command(
+		"python3 ../tools/cbor_item_count.py --hex \"A1 61 61\"");
+
+	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
+}

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -75,3 +75,18 @@ TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
 
 	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
 }
+
+TEST(ToolItemCount,
+     ShouldPrintBreakWhenTopLevelIndefiniteArrayContainsNestedIndefiniteArray)
+{
+	if (!can_run_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(("python3 \"" + get_script_path() +
+				       "\" --hex \"9f 9f 01 ff 02 ff\"")
+					      .c_str());
+
+	STRCMP_CONTAINS("error: CBOR_BREAK", out.c_str());
+	STRCMP_CONTAINS("items: 6", out.c_str());
+}

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -89,6 +89,21 @@ TEST(ToolItemCount, ShouldPrintIllegalForTruncatedDefiniteMap)
 }
 
 TEST(ToolItemCount,
+	     ShouldPrintSuccessWhenDefiniteArrayContainsIndefiniteTextString)
+{
+	if (!require_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(("python3 \"" + get_script_path() +
+				       "\" --hex \"81 7f 61 61 ff\"")
+				      .c_str());
+
+	STRCMP_CONTAINS("error: CBOR_SUCCESS", out.c_str());
+	STRCMP_CONTAINS("items: 4", out.c_str());
+}
+
+TEST(ToolItemCount,
      ShouldPrintBreakWhenTopLevelIndefiniteArrayContainsNestedIndefiniteArray)
 {
 	if (!require_item_count_tool()) {

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstdlib>
 #include <cstdio>
+#include <stdio.h>
 #include <string>
 
 #if defined(CBOR_PROJECT_ROOT)

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -156,3 +156,16 @@ TEST(ToolItemCount, ShouldPrintIllegalForMissingBreakInIndefiniteMap)
 
 	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
 }
+
+TEST(ToolItemCount, ShouldPrintIllegalForStandaloneBreak)
+{
+	if (!require_item_count_tool()) {
+		return;
+	}
+
+	std::string out = run_command(
+		("python3 \"" + get_script_path() + "\" --hex \"FF\"")
+			.c_str());
+
+	STRCMP_CONTAINS("error: CBOR_ILLEGAL", out.c_str());
+}

--- a/tests/src/tool_item_count_test.cpp
+++ b/tests/src/tool_item_count_test.cpp
@@ -1,16 +1,19 @@
 #include "CppUTest/TestHarness.h"
 
+#include <array>
 #include <cstdlib>
 #include <cstdio>
 #include <string>
 
-#if !defined(CBOR_PROJECT_ROOT)
-#define CBOR_PROJECT_ROOT ".."
+#if defined(CBOR_PROJECT_ROOT)
+static constexpr const char *kProjectRoot = CBOR_PROJECT_ROOT;
+#else
+static constexpr const char *kProjectRoot = "..";
 #endif
 
 static std::string get_script_path(void)
 {
-	return std::string(CBOR_PROJECT_ROOT) + "/tools/cbor_item_count.py";
+	return std::string(kProjectRoot) + "/tools/cbor_item_count.py";
 }
 
 static bool can_run_item_count_tool(void)
@@ -20,7 +23,7 @@ static bool can_run_item_count_tool(void)
 	}
 
 	FILE *fp = std::fopen(get_script_path().c_str(), "r");
-	if (fp == NULL) {
+	if (fp == nullptr) {
 		return false;
 	}
 
@@ -31,12 +34,13 @@ static bool can_run_item_count_tool(void)
 static std::string run_command(const char *command)
 {
 	std::string output;
-	char buffer[256];
+	std::array<char, 256> buffer{};
 	FILE *pipe = popen(command, "r");
 
-	CHECK_TEXT(pipe != NULL, "popen failed");
-	while (fgets(buffer, (int)sizeof(buffer), pipe) != NULL) {
-		output += buffer;
+	CHECK_TEXT(pipe != nullptr, "popen failed");
+	while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) !=
+	       nullptr) {
+		output += buffer.data();
 	}
 	pclose(pipe);
 

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -69,8 +69,9 @@ class Counter:
             err = CBOR_SUCCESS
             i = 0
             while self._can_parse_next(maxitems, i):
+                cur = self.data[self.msgidx]
                 err = self._parse_one_item()
-                if self._should_stop_after_item(err, maxitems):
+                if self._should_stop_after_item(err, maxitems, cur):
                     break
 
                 err = CBOR_SUCCESS
@@ -110,9 +111,12 @@ class Counter:
             return self.do_float_and_other(following_bytes)
         return CBOR_ILLEGAL
 
-    def _should_stop_after_item(self, err: str, maxitems: int) -> bool:
+    def _should_stop_after_item(self, err: str, maxitems: int, cur: int) -> bool:
         if err == CBOR_BREAK:
-            return maxitems == CBOR_INDEFINITE_VALUE or self.msgidx == self.msgsize
+            direct_break = cur == 0xFF
+            indefinite = maxitems == CBOR_INDEFINITE_VALUE
+            at_end = self.msgidx == self.msgsize
+            return (direct_break and indefinite) or at_end
         return err != CBOR_SUCCESS
 
     def do_integer(self, following_bytes: int):

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -82,7 +82,7 @@ class Counter:
             elif major_type in (2, 3):
                 err = self.do_string(additional_info, following_bytes)
             elif major_type in (4, 5):
-                err = self.do_recursive(additional_info, following_bytes)
+                err = self.do_recursive(major_type, additional_info, following_bytes)
             elif major_type == 6:
                 err = CBOR_INVALID
             elif major_type == 7:
@@ -114,21 +114,37 @@ class Counter:
         self.itemidx += 1
 
         if length == CBOR_INDEFINITE_VALUE:
-            return self.parse(CBOR_INDEFINITE_VALUE)
+            err = self.parse(CBOR_INDEFINITE_VALUE)
+            return err
         if length > (self.msgsize - self.msgidx):
             return CBOR_ILLEGAL
 
         self.msgidx += length
         return CBOR_SUCCESS
 
-    def do_recursive(self, additional_info: int, following_bytes: int):
+    def do_recursive(self, major_type: int, additional_info: int,
+                     following_bytes: int):
         length = self.go_get_item_length(additional_info, following_bytes)
+        expected_items = length
         self.itemidx += 1
 
-        if length != CBOR_INDEFINITE_VALUE and length > (self.msgsize - self.msgidx):
-            return CBOR_ILLEGAL
+        if length != CBOR_INDEFINITE_VALUE and major_type == 5:
+            expected_items = length * 2
 
-        return self.parse(length)
+        if length == CBOR_INDEFINITE_VALUE:
+            err = self.parse(CBOR_INDEFINITE_VALUE)
+            return err
+
+        for _ in range(expected_items):
+            itemidx_before = self.itemidx
+            msgidx_before = self.msgidx
+            err = self.parse(1)
+            if err != CBOR_SUCCESS:
+                return err
+            if self.itemidx == itemidx_before and self.msgidx == msgidx_before:
+                return CBOR_ILLEGAL
+
+        return CBOR_SUCCESS
 
     def do_float_and_other(self, following_bytes: int):
         if following_bytes == CBOR_INDEFINITE_VALUE:

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -131,6 +131,8 @@ class Counter:
 
         if length == CBOR_INDEFINITE_VALUE:
             err = self.parse(CBOR_INDEFINITE_VALUE)
+            if err == CBOR_SUCCESS:
+                return CBOR_ILLEGAL
             return err
         if length > (self.msgsize - self.msgidx):
             return CBOR_ILLEGAL
@@ -149,6 +151,8 @@ class Counter:
 
         if length == CBOR_INDEFINITE_VALUE:
             err = self.parse(CBOR_INDEFINITE_VALUE)
+            if err == CBOR_SUCCESS:
+                return CBOR_ILLEGAL
             return err
 
         for _ in range(expected_items):

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -71,7 +71,7 @@ class Counter:
             while self._can_parse_next(maxitems, i):
                 cur = self.data[self.msgidx]
                 err = self._parse_one_item()
-                if self._should_stop_after_item(err, maxitems, cur):
+                if self._should_stop_after_item(err, cur):
                     break
 
                 err = CBOR_SUCCESS
@@ -111,7 +111,7 @@ class Counter:
             return self.do_float_and_other(following_bytes)
         return CBOR_ILLEGAL
 
-    def _should_stop_after_item(self, err: str, maxitems: int, cur: int) -> bool:
+    def _should_stop_after_item(self, err: str, cur: int) -> bool:
         if err == CBOR_BREAK:
             direct_break = cur == 0xFF
             at_end = self.msgidx == self.msgsize

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -71,7 +71,13 @@ class Counter:
             while self._can_parse_next(maxitems, i):
                 cur = self.data[self.msgidx]
                 err = self._parse_one_item()
-                if self._should_stop_after_item(err, cur):
+                if err == CBOR_BREAK:
+                    if self._is_illegal_break(cur, maxitems):
+                        err = CBOR_ILLEGAL
+                        break
+                    if self._should_stop_after_item(cur, maxitems):
+                        break
+                elif err != CBOR_SUCCESS:
                     break
 
                 err = CBOR_SUCCESS
@@ -111,12 +117,14 @@ class Counter:
             return self.do_float_and_other(following_bytes)
         return CBOR_ILLEGAL
 
-    def _should_stop_after_item(self, err: str, cur: int) -> bool:
-        if err == CBOR_BREAK:
-            direct_break = cur == 0xFF
-            at_end = self.msgidx == self.msgsize
-            return direct_break or at_end
-        return err != CBOR_SUCCESS
+    def _is_illegal_break(self, cur: int, maxitems: int) -> bool:
+        return cur == 0xFF and maxitems != CBOR_INDEFINITE_VALUE
+
+    def _should_stop_after_item(self, cur: int, maxitems: int) -> bool:
+        direct_break = cur == 0xFF
+        indefinite = maxitems == CBOR_INDEFINITE_VALUE
+        at_end = not indefinite and self.msgidx == self.msgsize
+        return (direct_break and indefinite) or at_end
 
     def do_integer(self, following_bytes: int):
         if following_bytes == CBOR_INDEFINITE_VALUE:

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -114,9 +114,8 @@ class Counter:
     def _should_stop_after_item(self, err: str, maxitems: int, cur: int) -> bool:
         if err == CBOR_BREAK:
             direct_break = cur == 0xFF
-            indefinite = maxitems == CBOR_INDEFINITE_VALUE
             at_end = self.msgidx == self.msgsize
-            return (direct_break and indefinite) or at_end
+            return direct_break or at_end
         return err != CBOR_SUCCESS
 
     def do_integer(self, following_bytes: int):
@@ -156,6 +155,8 @@ class Counter:
             itemidx_before = self.itemidx
             msgidx_before = self.msgidx
             err = self.parse(1)
+            if err == CBOR_BREAK:
+                return CBOR_ILLEGAL
             if err != CBOR_SUCCESS:
                 return err
             if self.itemidx == itemidx_before and self.msgidx == msgidx_before:

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -13,7 +13,7 @@ CBOR_EXCESSIVE = "CBOR_EXCESSIVE"
 
 CBOR_INDEFINITE_VALUE = -1
 CBOR_RESERVED_VALUE = -2
-CBOR_RECURSION_MAX_LEVEL = 8
+DEFAULT_CBOR_RECURSION_MAX_LEVEL = 8
 
 
 def get_following_bytes(additional_info: int) -> int:
@@ -27,12 +27,13 @@ def get_following_bytes(additional_info: int) -> int:
 
 
 class Counter:
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes, max_depth: int = DEFAULT_CBOR_RECURSION_MAX_LEVEL):
         self.data = data
         self.msgsize = len(data)
         self.msgidx = 0
         self.itemidx = 0
         self.recursion_depth = 0
+        self.max_depth = max_depth
 
     def has_valid_following_bytes(self, following_bytes: int):
         if following_bytes == CBOR_RESERVED_VALUE:
@@ -60,7 +61,7 @@ class Counter:
 
     def parse(self, maxitems: int):
         self.recursion_depth += 1
-        if self.recursion_depth > CBOR_RECURSION_MAX_LEVEL:
+        if self.recursion_depth > self.max_depth:
             self.recursion_depth -= 1
             return CBOR_EXCESSIVE
 
@@ -144,8 +145,8 @@ class Counter:
         return CBOR_SUCCESS
 
 
-def count_items(data: bytes):
-    counter = Counter(data)
+def count_items(data: bytes, max_depth: int = DEFAULT_CBOR_RECURSION_MAX_LEVEL):
+    counter = Counter(data, max_depth=max_depth)
     err = counter.parse(counter.msgsize)
     if err == CBOR_SUCCESS and counter.msgidx < counter.msgsize:
         err = CBOR_OVERRUN
@@ -195,7 +196,20 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Count CBOR items from input message")
     parser.add_argument("--hex", help="CBOR bytes as hex string")
     parser.add_argument("--file", help="path to CBOR binary file")
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=DEFAULT_CBOR_RECURSION_MAX_LEVEL,
+        help=(
+            "maximum recursion depth to allow while parsing "
+            f"(default: {DEFAULT_CBOR_RECURSION_MAX_LEVEL})"
+        ),
+    )
     args = parser.parse_args()
+
+    if args.max_depth < 1:
+        print("input error: --max-depth must be >= 1", file=sys.stderr)
+        return 2
 
     try:
         data = load_input(args)
@@ -203,7 +217,7 @@ def main() -> int:
         print(f"input error: {e}", file=sys.stderr)
         return 2
 
-    err, nitems = count_items(data)
+    err, nitems = count_items(data, max_depth=args.max_depth)
     print(f"error: {err}")
     print(f"items: {nitems}")
 

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -160,7 +160,14 @@ class Counter:
             msgidx_before = self.msgidx
             err = self.parse(1)
             if err == CBOR_BREAK:
-                return CBOR_ILLEGAL
+                direct_break = (
+                    msgidx_before < self.msgsize and
+                    self.data[msgidx_before] == 0xFF and
+                    self.itemidx == itemidx_before + 1
+                )
+                if direct_break:
+                    return CBOR_ILLEGAL
+                err = CBOR_SUCCESS
             if err != CBOR_SUCCESS:
                 return err
             if self.itemidx == itemidx_before and self.msgidx == msgidx_before:

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -146,7 +146,7 @@ class Counter:
 
 def count_items(data: bytes):
     counter = Counter(data)
-    err = counter.parse(CBOR_INDEFINITE_VALUE)
+    err = counter.parse(counter.msgsize)
     if err == CBOR_SUCCESS and counter.msgidx < counter.msgsize:
         err = CBOR_OVERRUN
     return err, counter.itemidx

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -65,42 +65,55 @@ class Counter:
             self.recursion_depth -= 1
             return CBOR_EXCESSIVE
 
-        err = CBOR_SUCCESS
-        i = 0
-        while (maxitems == CBOR_INDEFINITE_VALUE or i < maxitems) and self.msgidx < self.msgsize:
-            val = self.data[self.msgidx]
-            major_type = val >> 5
-            additional_info = val & 0x1F
-            following_bytes = get_following_bytes(additional_info)
-
-            ok, err = self.has_valid_following_bytes(following_bytes)
-            if not ok:
-                break
-
-            if major_type in (0, 1):
-                err = self.do_integer(following_bytes)
-            elif major_type in (2, 3):
-                err = self.do_string(additional_info, following_bytes)
-            elif major_type in (4, 5):
-                err = self.do_recursive(major_type, additional_info, following_bytes)
-            elif major_type == 6:
-                err = CBOR_INVALID
-            elif major_type == 7:
-                err = self.do_float_and_other(following_bytes)
-            else:
-                err = CBOR_ILLEGAL
-
-            if err == CBOR_BREAK:
-                if maxitems == CBOR_INDEFINITE_VALUE or self.msgidx == self.msgsize:
-                    break
-            elif err != CBOR_SUCCESS:
-                break
-
+        try:
             err = CBOR_SUCCESS
-            i += 1
+            i = 0
+            while self._can_parse_next(maxitems, i):
+                err = self._parse_one_item()
+                if self._should_stop_after_item(err, maxitems):
+                    break
 
-        self.recursion_depth -= 1
-        return err
+                err = CBOR_SUCCESS
+                i += 1
+
+            return err
+        finally:
+            self.recursion_depth -= 1
+
+    def _can_parse_next(self, maxitems: int, parsed_items: int) -> bool:
+        limit_ok = maxitems == CBOR_INDEFINITE_VALUE or parsed_items < maxitems
+        return limit_ok and self.msgidx < self.msgsize
+
+    def _parse_one_item(self):
+        val = self.data[self.msgidx]
+        major_type = val >> 5
+        additional_info = val & 0x1F
+        following_bytes = get_following_bytes(additional_info)
+
+        ok, err = self.has_valid_following_bytes(following_bytes)
+        if not ok:
+            return err
+
+        return self._dispatch_parser(major_type, additional_info, following_bytes)
+
+    def _dispatch_parser(self, major_type: int, additional_info: int,
+                         following_bytes: int):
+        if major_type in (0, 1):
+            return self.do_integer(following_bytes)
+        if major_type in (2, 3):
+            return self.do_string(additional_info, following_bytes)
+        if major_type in (4, 5):
+            return self.do_recursive(major_type, additional_info, following_bytes)
+        if major_type == 6:
+            return CBOR_INVALID
+        if major_type == 7:
+            return self.do_float_and_other(following_bytes)
+        return CBOR_ILLEGAL
+
+    def _should_stop_after_item(self, err: str, maxitems: int) -> bool:
+        if err == CBOR_BREAK:
+            return maxitems == CBOR_INDEFINITE_VALUE or self.msgidx == self.msgsize
+        return err != CBOR_SUCCESS
 
     def do_integer(self, following_bytes: int):
         if following_bytes == CBOR_INDEFINITE_VALUE:

--- a/tools/cbor_item_count.py
+++ b/tools/cbor_item_count.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+
+CBOR_SUCCESS = "CBOR_SUCCESS"
+CBOR_ILLEGAL = "CBOR_ILLEGAL"
+CBOR_INVALID = "CBOR_INVALID"
+CBOR_OVERRUN = "CBOR_OVERRUN"
+CBOR_BREAK = "CBOR_BREAK"
+CBOR_EXCESSIVE = "CBOR_EXCESSIVE"
+
+CBOR_INDEFINITE_VALUE = -1
+CBOR_RESERVED_VALUE = -2
+CBOR_RECURSION_MAX_LEVEL = 8
+
+
+def get_following_bytes(additional_info: int) -> int:
+    if additional_info < 24:
+        return 0
+    if additional_info == 31:
+        return CBOR_INDEFINITE_VALUE
+    if additional_info >= 28:
+        return CBOR_RESERVED_VALUE
+    return 1 << (additional_info - 24)
+
+
+class Counter:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.msgsize = len(data)
+        self.msgidx = 0
+        self.itemidx = 0
+        self.recursion_depth = 0
+
+    def has_valid_following_bytes(self, following_bytes: int):
+        if following_bytes == CBOR_RESERVED_VALUE:
+            return False, CBOR_ILLEGAL
+        if following_bytes == CBOR_INDEFINITE_VALUE:
+            return True, CBOR_SUCCESS
+        if (following_bytes + 1) > (self.msgsize - self.msgidx):
+            return False, CBOR_ILLEGAL
+        return True, CBOR_SUCCESS
+
+    def go_get_item_length(self, additional_info: int, following_bytes: int):
+        if following_bytes == CBOR_INDEFINITE_VALUE:
+            length = CBOR_INDEFINITE_VALUE
+            offset = 0
+        elif following_bytes == 0:
+            length = additional_info
+            offset = 0
+        else:
+            begin = self.msgidx + 1
+            end = begin + following_bytes
+            length = int.from_bytes(self.data[begin:end], byteorder="big", signed=False)
+            offset = following_bytes
+        self.msgidx += offset + 1
+        return length
+
+    def parse(self, maxitems: int):
+        self.recursion_depth += 1
+        if self.recursion_depth > CBOR_RECURSION_MAX_LEVEL:
+            self.recursion_depth -= 1
+            return CBOR_EXCESSIVE
+
+        err = CBOR_SUCCESS
+        i = 0
+        while (maxitems == CBOR_INDEFINITE_VALUE or i < maxitems) and self.msgidx < self.msgsize:
+            val = self.data[self.msgidx]
+            major_type = val >> 5
+            additional_info = val & 0x1F
+            following_bytes = get_following_bytes(additional_info)
+
+            ok, err = self.has_valid_following_bytes(following_bytes)
+            if not ok:
+                break
+
+            if major_type in (0, 1):
+                err = self.do_integer(following_bytes)
+            elif major_type in (2, 3):
+                err = self.do_string(additional_info, following_bytes)
+            elif major_type in (4, 5):
+                err = self.do_recursive(additional_info, following_bytes)
+            elif major_type == 6:
+                err = CBOR_INVALID
+            elif major_type == 7:
+                err = self.do_float_and_other(following_bytes)
+            else:
+                err = CBOR_ILLEGAL
+
+            if err == CBOR_BREAK:
+                if maxitems == CBOR_INDEFINITE_VALUE or self.msgidx == self.msgsize:
+                    break
+            elif err != CBOR_SUCCESS:
+                break
+
+            err = CBOR_SUCCESS
+            i += 1
+
+        self.recursion_depth -= 1
+        return err
+
+    def do_integer(self, following_bytes: int):
+        if following_bytes == CBOR_INDEFINITE_VALUE:
+            return CBOR_ILLEGAL
+        self.msgidx += following_bytes + 1
+        self.itemidx += 1
+        return CBOR_SUCCESS
+
+    def do_string(self, additional_info: int, following_bytes: int):
+        length = self.go_get_item_length(additional_info, following_bytes)
+        self.itemidx += 1
+
+        if length == CBOR_INDEFINITE_VALUE:
+            return self.parse(CBOR_INDEFINITE_VALUE)
+        if length > (self.msgsize - self.msgidx):
+            return CBOR_ILLEGAL
+
+        self.msgidx += length
+        return CBOR_SUCCESS
+
+    def do_recursive(self, additional_info: int, following_bytes: int):
+        length = self.go_get_item_length(additional_info, following_bytes)
+        self.itemidx += 1
+
+        if length != CBOR_INDEFINITE_VALUE and length > (self.msgsize - self.msgidx):
+            return CBOR_ILLEGAL
+
+        return self.parse(length)
+
+    def do_float_and_other(self, following_bytes: int):
+        if following_bytes == CBOR_INDEFINITE_VALUE:
+            self.msgidx += 1
+            self.itemidx += 1
+            return CBOR_BREAK
+
+        ok, err = self.has_valid_following_bytes(following_bytes)
+        if not ok:
+            return err
+
+        self.msgidx += following_bytes + 1
+        self.itemidx += 1
+        return CBOR_SUCCESS
+
+
+def count_items(data: bytes):
+    counter = Counter(data)
+    err = counter.parse(CBOR_INDEFINITE_VALUE)
+    if err == CBOR_SUCCESS and counter.msgidx < counter.msgsize:
+        err = CBOR_OVERRUN
+    return err, counter.itemidx
+
+
+def parse_hex_input(hex_input: str) -> bytes:
+    s = hex_input.strip()
+    if not s:
+        return b""
+
+    s = s.replace(",", " ")
+    if any(ch.isspace() for ch in s):
+        tokens = [t for t in re.split(r"\s+", s) if t]
+        parts = []
+        for t in tokens:
+            if t.lower().startswith("0x"):
+                t = t[2:]
+            if len(t) == 0:
+                continue
+            if len(t) % 2 != 0:
+                t = "0" + t
+            parts.append(t)
+        return bytes.fromhex("".join(parts))
+
+    if s.lower().startswith("0x"):
+        s = s[2:]
+    if len(s) % 2 != 0:
+        s = "0" + s
+    return bytes.fromhex(s)
+
+
+def load_input(args) -> bytes:
+    if args.hex is not None:
+        return parse_hex_input(args.hex)
+    if args.file is not None:
+        with open(args.file, "rb") as f:
+            return f.read()
+
+    data = sys.stdin.buffer.read()
+    if not data:
+        raise ValueError("no input given")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Count CBOR items from input message")
+    parser.add_argument("--hex", help="CBOR bytes as hex string")
+    parser.add_argument("--file", help="path to CBOR binary file")
+    args = parser.parse_args()
+
+    try:
+        data = load_input(args)
+    except Exception as e:
+        print(f"input error: {e}", file=sys.stderr)
+        return 2
+
+    err, nitems = count_items(data)
+    print(f"error: {err}")
+    print(f"items: {nitems}")
+
+    if err in (CBOR_SUCCESS, CBOR_BREAK):
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This pull request introduces a new feature to efficiently count the number of CBOR items in a message without allocating item buffers, along with documentation and tests. The main changes include the addition of the `cbor_count_items()` API, supporting implementation in the parser, and updates to documentation and tests to reflect and validate this new capability.

**New CBOR item counting API:**

* Added the `cbor_count_items()` function to `include/cbor/parser.h`, allowing users to count the number of CBOR items in a message without allocating buffer space for item metadata.
* Implemented the `cbor_count_items()` logic in `src/parser.c` by introducing a `dry_run` mode in the parser context, which walks the message and counts items without storing metadata. [[1]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccR23-R24) [[2]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccR255-R284)

**Parser refactoring for dry-run support:**

* Refactored item creation in `src/parser.c` to use a new `set_item()` helper, which is a no-op in dry-run mode, ensuring that item metadata is only stored when not counting. [[1]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccR131-R151) [[2]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL148-R163) [[3]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL171-R184) [[4]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL197-R222)
* Updated parser logic to support both normal and dry-run (counting) operation modes.

**Documentation and usage guidance:**

* Expanded the `README.md` with detailed explanations and examples for sizing the `items` buffer, using `cbor_count_items()` for pre-estimation, and handling capacity errors. Also documented a helper script for item counting.

**Testing improvements:**

* Added `tests/src/parser_count_test.cpp` with unit tests to verify the correct behavior of `cbor_count_items()` for valid messages, buffer overruns, and illegal/incomplete messages.
* Updated the test runner makefile to include the new test file.