### PR TITLE
feat(stream): add streaming CBOR decoder API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,11 @@ jobs:
         run: make -C tests
       - name: Get Version
         id: get_version
-        run: echo "::set-output name=VERSION::$(cat build/version.txt)"
+        run: echo "VERSION=$(cat build/version.txt)" >> $GITHUB_ENV
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
+        run: |
+          gh release create ${{ env.VERSION }} \
+            --title "${{ env.VERSION }}" \
+            --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
-          body: |
-            ${{ steps.get_version.outputs.VERSION }}
-
-            ## Features
-            ## Bug Fixes
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,10 @@ jobs:
         run: make -C tests install
       - name: Unit Test
         run: make -C tests
-      - name: Get Version
-        id: get_version
-        run: echo "VERSION=$(cat build/version.txt)" >> $GITHUB_ENV
       - name: Create Release
         run: |
-          gh release create ${{ env.VERSION }} \
-            --title "${{ env.VERSION }}" \
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
             --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ if (cbor_stream_finish(&decoder) != CBOR_SUCCESS) {
 | `data` | Decoded value; `NULL` for `_END` events |
 | `arg` | User-supplied context pointer passed to `cbor_stream_init()` |
 
-Note: The streaming decoder supports only one pending tag. A second tag
-before the tagged item resolves causes `cbor_stream_feed()` to return
-`CBOR_EXCESSIVE`.
+> [!NOTE]
+> The streaming decoder supports only one pending tag. A second tag
+> before the tagged item resolves causes `cbor_stream_feed()` to return
+> `CBOR_EXCESSIVE`.
 
 Returning `false` from the callback stops decoding and causes
 `cbor_stream_feed()` to return `CBOR_ABORTED`.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ the full message to be in memory first. It is push-based: feed any number of
 bytes at a time and receive events via a callback as items are decoded.
 
 ```c
+#include <stdio.h>
 #include <inttypes.h>
 #include "cbor/stream.h"
 
@@ -228,7 +229,7 @@ if (cbor_stream_finish(&decoder) != CBOR_SUCCESS) {
 }
 ```
 
-**Event callback** receives two arguments on every call:
+**Event callback** receives three arguments on every call:
 
 | Field | Description |
 | --- | --- |
@@ -238,6 +239,7 @@ if (cbor_stream_finish(&decoder) != CBOR_SUCCESS) {
 | `event->has_tag` | `true` when the item carries a CBOR tag |
 | `event->tag` | Tag number (valid only when `has_tag` is `true`) |
 | `data` | Decoded value; `NULL` for `_END` events |
+| `arg` | User-supplied context pointer passed to `cbor_stream_init()` |
 
 Returning `false` from the callback stops decoding and causes
 `cbor_stream_feed()` to return `CBOR_ABORTED`.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ static bool on_event(const cbor_stream_event_t *event,
         break;
     case CBOR_STREAM_EVENT_TEXT:
         printf("text: %.*s (first=%d last=%d)\n",
-                (int)data->str.len, data->str.ptr,
+                data->str.ptr ? (int)data->str.len : 0,
+                data->str.ptr ? (const char *)data->str.ptr : "",
                 data->str.first, data->str.last);
         break;
     case CBOR_STREAM_EVENT_MAP_START:

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ the full message to be in memory first. It is push-based: feed any number of
 bytes at a time and receive events via a callback as items are decoded.
 
 ```c
+#include <inttypes.h>
 #include "cbor/stream.h"
 
 static bool on_event(const cbor_stream_event_t *event,
@@ -194,7 +195,7 @@ static bool on_event(const cbor_stream_event_t *event,
 {
     switch (event->type) {
     case CBOR_STREAM_EVENT_UINT:
-        printf("uint: %llu (depth=%u)\n", data->uint, event->depth);
+        printf("uint: %" PRIu64 " (depth=%u)\n", data->uint, event->depth);
         break;
     case CBOR_STREAM_EVENT_TEXT:
         printf("text: %.*s (first=%d last=%d)\n",
@@ -202,7 +203,7 @@ static bool on_event(const cbor_stream_event_t *event,
                 data->str.first, data->str.last);
         break;
     case CBOR_STREAM_EVENT_MAP_START:
-        printf("map start (size=%lld)\n", data->container.size);
+        printf("map start (size=%" PRId64 ")\n", data->container.size);
         break;
     case CBOR_STREAM_EVENT_MAP_END:
         printf("map end\n");

--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ carry chunk metadata in `data->str`:
 | `last` | `true` on the last chunk |
 
 A definite-length string may arrive in multiple chunks when the payload
-spans several `cbor_stream_feed()` calls. An indefinite-length string emits
-one chunk per CBOR sub-chunk, followed by a zero-length chunk with
+spans several `cbor_stream_feed()` calls. An indefinite-length string may emit
+one or more chunks per CBOR sub-chunk, followed by a zero-length chunk with
 `last = true` for the BREAK terminator.
 
 **Container events** (`_ARRAY_START` / `_MAP_START`) carry

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ if (cbor_stream_finish(&decoder) != CBOR_SUCCESS) {
 | `data` | Decoded value; `NULL` for `_END` events |
 | `arg` | User-supplied context pointer passed to `cbor_stream_init()` |
 
+Note: The streaming decoder supports only one pending tag. A second tag
+before the tagged item resolves causes `cbor_stream_feed()` to return
+`CBOR_EXCESSIVE`.
+
 Returning `false` from the callback stops decoding and causes
 `cbor_stream_feed()` to return `CBOR_ABORTED`.
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,11 @@ static bool on_event(const cbor_stream_event_t *event,
         printf("uint: %" PRIu64 " (depth=%u)\n", data->uint, event->depth);
         break;
     case CBOR_STREAM_EVENT_TEXT:
-        printf("text: %.*s (first=%d last=%d)\n",
-                data->str.ptr ? (int)data->str.len : 0,
-                data->str.ptr ? (const char *)data->str.ptr : "",
+        printf("text: ");
+        if (data->str.ptr) {
+            fwrite(data->str.ptr, 1, data->str.len, stdout);
+        }
+        printf(" (first=%d last=%d)\n",
                 data->str.first, data->str.last);
         break;
     case CBOR_STREAM_EVENT_MAP_START:

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ or `-1` for indefinite-length.
 **API summary:**
 
 ```c
-/* Initialize (callback must not be NULL) */
+/* Initialize (NULL callback is allowed, but feed/finish will return CBOR_INVALID) */
 void cbor_stream_init(cbor_stream_decoder_t *decoder,
         cbor_stream_callback_t callback, void *arg);
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,108 @@ if (err == CBOR_OVERRUN) {
 In this case, `n` contains only the number of items actually stored before the
 overrun.
 
+### Streaming Decoder
+
+The streaming decoder processes CBOR bytes incrementally without requiring
+the full message to be in memory first. It is push-based: feed any number of
+bytes at a time and receive events via a callback as items are decoded.
+
+```c
+#include "cbor/stream.h"
+
+static bool on_event(const cbor_stream_event_t *event,
+        const cbor_stream_data_t *data, void *arg)
+{
+    switch (event->type) {
+    case CBOR_STREAM_EVENT_UINT:
+        printf("uint: %llu (depth=%u)\n", data->uint, event->depth);
+        break;
+    case CBOR_STREAM_EVENT_TEXT:
+        printf("text: %.*s (first=%d last=%d)\n",
+                (int)data->str.len, data->str.ptr,
+                data->str.first, data->str.last);
+        break;
+    case CBOR_STREAM_EVENT_MAP_START:
+        printf("map start (size=%lld)\n", data->container.size);
+        break;
+    case CBOR_STREAM_EVENT_MAP_END:
+        printf("map end\n");
+        break;
+    default:
+        break;
+    }
+    return true; /* return false to abort decoding */
+}
+
+cbor_stream_decoder_t decoder;
+cbor_stream_init(&decoder, on_event, NULL);
+
+/* Feed in any chunk size */
+cbor_stream_feed(&decoder, chunk1, chunk1_len);
+cbor_stream_feed(&decoder, chunk2, chunk2_len);
+
+/* Verify all items were complete */
+if (cbor_stream_finish(&decoder) != CBOR_SUCCESS) {
+    /* truncated input */
+}
+```
+
+**Event callback** receives two arguments on every call:
+
+| Field | Description |
+| --- | --- |
+| `event->type` | Item type (`CBOR_STREAM_EVENT_UINT`, `_TEXT`, `_ARRAY_START`, …) |
+| `event->depth` | Nesting depth (0 = top level) |
+| `event->is_map_key` | `true` when the item is a map key |
+| `event->has_tag` | `true` when the item carries a CBOR tag |
+| `event->tag` | Tag number (valid only when `has_tag` is `true`) |
+| `data` | Decoded value; `NULL` for `_END` events |
+
+Returning `false` from the callback stops decoding and causes
+`cbor_stream_feed()` to return `CBOR_ABORTED`.
+
+**String events** (`CBOR_STREAM_EVENT_BYTES` / `CBOR_STREAM_EVENT_TEXT`)
+carry chunk metadata in `data->str`:
+
+| Field | Description |
+| --- | --- |
+| `ptr` | Pointer into the caller's feed buffer (valid during the callback) |
+| `len` | Bytes in this chunk |
+| `total` | Total string length; `-1` for indefinite-length strings |
+| `first` | `true` on the first chunk |
+| `last` | `true` on the last chunk |
+
+A definite-length string may arrive in multiple chunks when the payload
+spans several `cbor_stream_feed()` calls. An indefinite-length string emits
+one chunk per CBOR sub-chunk, followed by a zero-length chunk with
+`last = true` for the BREAK terminator.
+
+**Container events** (`_ARRAY_START` / `_MAP_START`) carry
+`data->container.size`: the number of items (array) or key-value pairs (map),
+or `-1` for indefinite-length.
+
+**API summary:**
+
+```c
+/* Initialize (callback must not be NULL) */
+void cbor_stream_init(cbor_stream_decoder_t *decoder,
+        cbor_stream_callback_t callback, void *arg);
+
+/* Push bytes; may be called repeatedly with any chunk size */
+cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
+        const void *data, size_t len);
+
+/* Signal end-of-input; returns CBOR_NEED_MORE if input was truncated */
+cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder);
+
+/* Reset to initial state (preserves callback and arg) */
+void cbor_stream_reset(cbor_stream_decoder_t *decoder);
+```
+
+After any error `cbor_stream_feed()` enters a sticky error state and returns
+the same error on subsequent calls. Use `cbor_stream_reset()` to reuse the
+decoder.
+
 ## Tools
 
 ### Item counter script

--- a/cbor.cmake
+++ b/cbor.cmake
@@ -7,5 +7,6 @@ list(APPEND CBOR_SRCS
 	${CMAKE_CURRENT_LIST_DIR}/src/encoder.c
 	${CMAKE_CURRENT_LIST_DIR}/src/helper.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ieee754.c
+	${CMAKE_CURRENT_LIST_DIR}/src/stream.c
 )
 list(APPEND CBOR_INCS ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/cbor.mk
+++ b/cbor.mk
@@ -11,5 +11,6 @@ CBOR_SRCS := \
 	$(cbor-basedir)src/encoder.c \
 	$(cbor-basedir)src/helper.c \
 	$(cbor-basedir)src/ieee754.c \
+	$(cbor-basedir)src/stream.c \
 
 CBOR_INCS := $(cbor-basedir)include

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -34,6 +34,8 @@ typedef enum {
 	CBOR_OVERRUN, /**< more items than given buffer space */
 	CBOR_BREAK,
 	CBOR_EXCESSIVE, /**< recursion more than @ref CBOR_RECURSION_MAX_LEVEL */
+	CBOR_NEED_MORE, /**< stream ended before item complete */
+	CBOR_ABORTED, /**< callback returned false */
 } cbor_error_t;
 
 typedef enum {

--- a/include/cbor/cbor.h
+++ b/include/cbor/cbor.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "cbor/decoder.h"
 #include "cbor/encoder.h"
 #include "cbor/helper.h"
+#include "cbor/stream.h"
 
 #if defined(__cplusplus)
 }

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -103,7 +103,8 @@ typedef struct {
  * Initialize a streaming CBOR decoder.
  *
  * @param[in,out] decoder  decoder context allocated by caller
- * @param[in]     callback event callback; must not be NULL
+ * @param[in]     callback event callback; if NULL, subsequent feed/finish
+ *                           calls return CBOR_INVALID
  * @param[in]     arg      opaque pointer forwarded to every callback
  */
 void cbor_stream_init(cbor_stream_decoder_t *decoder,

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -1,0 +1,149 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef CBOR_STREAM_H
+#define CBOR_STREAM_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include "cbor/base.h"
+
+typedef enum {
+	CBOR_STREAM_EVENT_UINT,
+	CBOR_STREAM_EVENT_INT,
+	CBOR_STREAM_EVENT_BYTES,
+	CBOR_STREAM_EVENT_TEXT,
+	CBOR_STREAM_EVENT_ARRAY_START,
+	CBOR_STREAM_EVENT_ARRAY_END,
+	CBOR_STREAM_EVENT_MAP_START,
+	CBOR_STREAM_EVENT_MAP_END,
+	CBOR_STREAM_EVENT_FLOAT,
+	CBOR_STREAM_EVENT_BOOL,
+	CBOR_STREAM_EVENT_NULL,
+	CBOR_STREAM_EVENT_UNDEFINED,
+	CBOR_STREAM_EVENT_SIMPLE,
+} cbor_stream_event_type_t;
+
+typedef struct {
+	cbor_stream_event_type_t type;
+	uint8_t  depth;
+	bool     is_map_key;
+	bool     has_tag;
+	uint64_t tag;
+} cbor_stream_event_t;
+
+typedef union {
+	uint64_t uint;
+	int64_t  sint;
+	struct {
+		const uint8_t *ptr;
+		size_t         len;
+		int64_t        total; /**< -1 if indefinite */
+		bool           first;
+		bool           last;
+	} str;
+	struct {
+		int64_t size; /**< -1 if indefinite */
+	} container;
+	double  flt;
+	bool    boolean;
+	uint8_t simple;
+} cbor_stream_data_t;
+
+/**
+ * Streaming event callback.
+ *
+ * @param[in] event structural context (type, depth, map position, tag)
+ * @param[in] data  decoded value; NULL for _END events
+ * @param[in] arg   user-supplied context pointer
+ *
+ * @return true to continue decoding, false to abort (CBOR_ABORTED)
+ */
+typedef bool (*cbor_stream_callback_t)(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg);
+
+typedef struct {
+	cbor_item_data_t type;
+	int64_t          count; /**< remaining items; -1 = indefinite */
+	bool             is_key;
+} cbor_stream_frame_t;
+
+typedef struct {
+	uint8_t state;
+	uint8_t major_type;
+	uint8_t additional_info;
+	uint8_t following_bytes;
+	uint8_t following_bytes_read;
+	uint8_t length_buf[8];
+
+	int64_t payload_remaining;
+	int64_t payload_total;
+	bool    payload_first_chunk;
+
+	bool    in_indef_str;
+	uint8_t indef_str_major;
+
+	bool     has_pending_tag;
+	uint64_t pending_tag;
+
+	cbor_stream_frame_t stack[CBOR_RECURSION_MAX_LEVEL];
+	uint8_t             depth;
+
+	cbor_error_t           error;
+	cbor_stream_callback_t callback;
+	void                  *callback_arg;
+} cbor_stream_decoder_t;
+
+/**
+ * Initialize a streaming CBOR decoder.
+ *
+ * @param[in,out] decoder  decoder context allocated by caller
+ * @param[in]     callback event callback; must not be NULL
+ * @param[in]     arg      opaque pointer forwarded to every callback
+ */
+void cbor_stream_init(cbor_stream_decoder_t *decoder,
+		cbor_stream_callback_t callback, void *arg);
+
+/**
+ * Feed bytes into the decoder.
+ *
+ * May be called repeatedly with any chunk size >=1 byte.
+ * After any non-CBOR_SUCCESS return the decoder enters a sticky error state;
+ * subsequent calls return the same error immediately.
+ *
+ * @param[in,out] decoder decoder context
+ * @param[in]     data    pointer to bytes to consume
+ * @param[in]     len     number of bytes in @p data
+ *
+ * @return CBOR_SUCCESS, CBOR_ILLEGAL, CBOR_INVALID, CBOR_EXCESSIVE, or
+ *         CBOR_ABORTED
+ */
+cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
+		const void *data, size_t len);
+
+/**
+ * Signal end of input and verify the decoder is in a clean idle state.
+ *
+ * @param[in,out] decoder decoder context
+ *
+ * @return CBOR_SUCCESS if all items were complete, CBOR_NEED_MORE otherwise
+ */
+cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder);
+
+/**
+ * Reset the decoder to its initial state so it can be reused.
+ *
+ * @param[in,out] decoder decoder context
+ */
+void cbor_stream_reset(cbor_stream_decoder_t *decoder);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* CBOR_STREAM_H */

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -129,19 +129,19 @@ cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
 
 /**
  * Signal end of input and verify the decoder is in a clean idle state.
-	 *
-	 * After any non-CBOR_SUCCESS return from cbor_stream_feed() the decoder
-	 * enters a sticky error state; in that case this function returns the same
-	 * error code without further processing.
+ *
+ * After any non-CBOR_SUCCESS return from cbor_stream_feed() the decoder
+ * enters a sticky error state; in that case this function returns the same
+ * error code without further processing.
  *
  * @param[in,out] decoder decoder context
  *
-	 * @return CBOR_SUCCESS if all items were complete and the decoder is idle;
-	 *         CBOR_NEED_MORE if the end of input was reached but additional
-	 *         bytes are required to complete the last item; CBOR_INVALID if
-	 *         @p decoder is NULL or the decoder has no valid callback; or the
-	 *         last non-success error previously returned by cbor_stream_feed()
-	 *         if the decoder is in a sticky error state
+ * @return CBOR_SUCCESS if all items were complete and the decoder is idle;
+ *         CBOR_NEED_MORE if the end of input was reached but additional
+ *         bytes are required to complete the last item; CBOR_INVALID if
+ *         @p decoder is NULL or the decoder has no valid callback; or the
+ *         last non-success error previously returned by cbor_stream_feed()
+ *         if the decoder is in a sticky error state
  */
 cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder);
 

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -129,10 +129,19 @@ cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
 
 /**
  * Signal end of input and verify the decoder is in a clean idle state.
+	 *
+	 * After any non-CBOR_SUCCESS return from cbor_stream_feed() the decoder
+	 * enters a sticky error state; in that case this function returns the same
+	 * error code without further processing.
  *
  * @param[in,out] decoder decoder context
  *
- * @return CBOR_SUCCESS if all items were complete, CBOR_NEED_MORE otherwise
+	 * @return CBOR_SUCCESS if all items were complete and the decoder is idle;
+	 *         CBOR_NEED_MORE if the end of input was reached but additional
+	 *         bytes are required to complete the last item; CBOR_INVALID if
+	 *         @p decoder is NULL or the decoder has no valid callback; or the
+	 *         last non-success error previously returned by cbor_stream_feed()
+	 *         if the decoder is in a sticky error state
  */
 cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder);
 

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -13,6 +13,9 @@ extern "C" {
 
 #include "cbor/base.h"
 
+typedef char cbor_stream_depth_must_fit_uint8_t[
+	(CBOR_RECURSION_MAX_LEVEL < 256) ? 1 : -1];
+
 typedef enum {
 	CBOR_STREAM_EVENT_UINT,
 	CBOR_STREAM_EVENT_INT,

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -112,7 +112,8 @@ void cbor_stream_init(cbor_stream_decoder_t *decoder,
 /**
  * Feed bytes into the decoder.
  *
- * May be called repeatedly with any chunk size >=1 byte.
+ * May be called repeatedly with any chunk size >=0 bytes.
+ * A zero-length feed is treated as a no-op and @p data may be NULL.
  * After any non-CBOR_SUCCESS return the decoder enters a sticky error state;
  * subsequent calls return the same error immediately.
  *

--- a/src/helper.c
+++ b/src/helper.c
@@ -201,6 +201,10 @@ const char *cbor_stringify_error(cbor_error_t err)
 		return "break";
 	case CBOR_EXCESSIVE:
 		return "too deep recursion";
+	case CBOR_NEED_MORE:
+		return "need more data";
+	case CBOR_ABORTED:
+		return "aborted";
 	case CBOR_ILLEGAL: /* fall through */
 	default:
 		return "not well-formed";

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ * SPDX-FileCopyrightText: 2021 권경환 Kyunghwan Kwon <k@libmcu.org>
  *
  * SPDX-License-Identifier: MIT
  */

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,12 +1,18 @@
 /*
- * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ * SPDX-FileCopyrightText: 2026 권경환 Kyunghwan Kwon <k@libmcu.org>
  *
  * SPDX-License-Identifier: MIT
  */
 
 #include "cbor/stream.h"
 #include "cbor/ieee754.h"
+
+#include <limits.h>
 #include <string.h>
+
+#if !defined(assert)
+#define assert(expr)
+#endif
 
 enum stream_state {
 	STREAM_STATE_IDLE    = 0,
@@ -15,7 +21,10 @@ enum stream_state {
 	STREAM_STATE_ERROR   = 3,
 };
 
-/* ---------- event helpers ---------- */
+static bool can_fit_int64(uint64_t value)
+{
+	return value <= (uint64_t)INT64_MAX;
+}
 
 static void build_event(cbor_stream_decoder_t *d,
 		cbor_stream_event_type_t type, cbor_stream_event_t *event)
@@ -40,8 +49,6 @@ static cbor_error_t invoke_cb(cbor_stream_decoder_t *d,
 	}
 	return CBOR_SUCCESS;
 }
-
-/* ---------- container helpers ---------- */
 
 static cbor_error_t emit_container_end(cbor_stream_decoder_t *d)
 {
@@ -69,10 +76,12 @@ static cbor_error_t after_item(cbor_stream_decoder_t *d)
 			break;
 		}
 
-		f->count--;
-		if (f->count > 0) {
+		if (f->count > 1) {
+			f->count--;
 			break;
 		}
+
+		f->count--; /* reaches 0: emit END */
 
 		cbor_error_t err = emit_container_end(d);
 		if (err != CBOR_SUCCESS) {
@@ -120,8 +129,6 @@ static cbor_error_t push_container(cbor_stream_decoder_t *d,
 	return CBOR_SUCCESS;
 }
 
-/* ---------- length decoding ---------- */
-
 static uint64_t decode_length_buf(const cbor_stream_decoder_t *d)
 {
 	uint64_t val = 0;
@@ -138,8 +145,6 @@ static uint64_t get_item_value(const cbor_stream_decoder_t *d)
 	}
 	return decode_length_buf(d);
 }
-
-/* ---------- float decoding ---------- */
 
 static double decode_float_value(const cbor_stream_decoder_t *d)
 {
@@ -158,8 +163,6 @@ static double decode_float_value(const cbor_stream_decoder_t *d)
 		return dbl;
 	}
 }
-
-/* ---------- item emitters ---------- */
 
 static cbor_error_t emit_uint(cbor_stream_decoder_t *d)
 {
@@ -182,8 +185,12 @@ static cbor_error_t emit_int(cbor_stream_decoder_t *d)
 	cbor_stream_data_t  data;
 	uint64_t raw = get_item_value(d);
 
+	if (!can_fit_int64(raw)) {
+		return CBOR_INVALID;
+	}
+
 	build_event(d, CBOR_STREAM_EVENT_INT, &event);
-	data.sint = (int64_t)(~raw);
+	data.sint = -(int64_t)raw - 1;
 
 	cbor_error_t err = invoke_cb(d, &event, &data);
 	if (err != CBOR_SUCCESS) {
@@ -258,8 +265,6 @@ static cbor_error_t emit_float(cbor_stream_decoder_t *d)
 	return after_item(d);
 }
 
-/* ---------- BREAK handling ---------- */
-
 static cbor_error_t handle_break(cbor_stream_decoder_t *d)
 {
 	if (d->in_indef_str) {
@@ -286,8 +291,6 @@ static cbor_error_t handle_break(cbor_stream_decoder_t *d)
 	return after_item(d);
 }
 
-/* ---------- process complete initial byte (no following bytes) ---------- */
-
 static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
 {
 	cbor_error_t err;
@@ -295,10 +298,8 @@ static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
 	switch (d->major_type) {
 	case 0: /* unsigned integer */
 		return emit_uint(d);
-
 	case 1: /* negative integer */
 		return emit_int(d);
-
 	case 2: /* byte string, length in additional_info */
 	case 3: /* text string, length in additional_info */ {
 		cbor_stream_event_type_t stype = (d->major_type == 2)
@@ -328,15 +329,12 @@ static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
 		d->state = STREAM_STATE_PAYLOAD;
 		return CBOR_SUCCESS;
 	}
-
 	case 4: /* definite array */
 		return push_container(d, CBOR_ITEM_ARRAY,
 				(int64_t)d->additional_info);
-
 	case 5: /* definite map */
 		return push_container(d, CBOR_ITEM_MAP,
 				(int64_t)(d->additional_info * 2));
-
 	case 6: /* tag, value in additional_info */
 		if (d->has_pending_tag) {
 			return CBOR_EXCESSIVE;
@@ -344,18 +342,14 @@ static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
 		d->has_pending_tag = true;
 		d->pending_tag     = (uint64_t)d->additional_info;
 		return CBOR_SUCCESS;
-
 	case 7: /* simple value (additional_info 0-23) */
 		/* additional_info >= 24 has following_bytes > 0, handled elsewhere;
 		 * additional_info == 31 (BREAK) is caught by handle_indefinite() */
 		return emit_simple(d, d->additional_info);
-
 	default:
 		return CBOR_ILLEGAL;
 	}
 }
-
-/* ---------- process complete length bytes ---------- */
 
 static cbor_error_t process_string_length(cbor_stream_decoder_t *d)
 {
@@ -365,6 +359,9 @@ static cbor_error_t process_string_length(cbor_stream_decoder_t *d)
 
 	/* For indefinite-string sub-chunks keep payload_total as -1 */
 	if (!d->in_indef_str) {
+		if (!can_fit_int64(len)) {
+			return CBOR_INVALID;
+		}
 		d->payload_total = (int64_t)len;
 	}
 
@@ -382,6 +379,10 @@ static cbor_error_t process_string_length(cbor_stream_decoder_t *d)
 		return CBOR_SUCCESS;
 	}
 
+	if (!can_fit_int64(len)) {
+		return CBOR_INVALID;
+	}
+
 	d->payload_remaining   = (int64_t)len;
 	d->payload_first_chunk = d->in_indef_str ? d->payload_first_chunk : true;
 	d->state = STREAM_STATE_PAYLOAD;
@@ -393,7 +394,20 @@ static cbor_error_t process_container_length(cbor_stream_decoder_t *d)
 	uint64_t n = decode_length_buf(d);
 	cbor_item_data_t type = (d->major_type == 4)
 		? CBOR_ITEM_ARRAY : CBOR_ITEM_MAP;
-	int64_t count = (type == CBOR_ITEM_MAP) ? (int64_t)(n * 2) : (int64_t)n;
+	int64_t count;
+
+	if (type == CBOR_ITEM_MAP) {
+		if (n > (uint64_t)(INT64_MAX / 2)) {
+			return CBOR_INVALID;
+		}
+		count = (int64_t)(n * 2u);
+	} else {
+		if (!can_fit_int64(n)) {
+			return CBOR_INVALID;
+		}
+		count = (int64_t)n;
+	}
+
 	return push_container(d, type, count);
 }
 
@@ -434,8 +448,6 @@ static cbor_error_t process_length_complete(cbor_stream_decoder_t *d)
 	}
 }
 
-/* ---------- indefinite-length starters ---------- */
-
 static cbor_error_t handle_indefinite(cbor_stream_decoder_t *d)
 {
 	switch (d->major_type) {
@@ -464,8 +476,6 @@ static cbor_error_t handle_indefinite(cbor_stream_decoder_t *d)
 		return CBOR_ILLEGAL;
 	}
 }
-
-/* ---------- initial byte parsing ---------- */
 
 static cbor_error_t process_initial_byte(cbor_stream_decoder_t *d, uint8_t b)
 {
@@ -505,11 +515,13 @@ static cbor_error_t process_initial_byte(cbor_stream_decoder_t *d, uint8_t b)
 	return CBOR_SUCCESS;
 }
 
-/* ---------- payload streaming ---------- */
-
 static cbor_error_t consume_payload(cbor_stream_decoder_t *d,
 		const uint8_t **p, size_t *remaining)
 {
+	if (d->payload_remaining <= 0) {
+		return CBOR_INVALID;
+	}
+
 	size_t avail = (size_t)d->payload_remaining;
 	if (avail > *remaining) {
 		avail = *remaining;
@@ -544,11 +556,16 @@ static cbor_error_t consume_payload(cbor_stream_decoder_t *d,
 	return CBOR_SUCCESS;
 }
 
-/* ---------- public API ---------- */
-
 void cbor_stream_init(cbor_stream_decoder_t *decoder,
 		cbor_stream_callback_t callback, void *arg)
 {
+	assert(decoder != NULL);
+	assert(callback != NULL);
+
+	if (decoder == NULL) {
+		return;
+	}
+
 	memset(decoder, 0, sizeof(*decoder));
 	decoder->callback     = callback;
 	decoder->callback_arg = arg;
@@ -558,6 +575,14 @@ void cbor_stream_init(cbor_stream_decoder_t *decoder,
 cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
 		const void *data, size_t len)
 {
+	if (decoder == NULL || decoder->callback == NULL) {
+		return CBOR_INVALID;
+	}
+
+	if (len > 0 && data == NULL) {
+		return CBOR_INVALID;
+	}
+
 	if (decoder->state == STREAM_STATE_ERROR) {
 		return decoder->error;
 	}
@@ -605,6 +630,10 @@ cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
 
 cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder)
 {
+	if (decoder == NULL || decoder->callback == NULL) {
+		return CBOR_INVALID;
+	}
+
 	if (decoder->state == STREAM_STATE_ERROR) {
 		return decoder->error;
 	}
@@ -620,6 +649,12 @@ cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder)
 
 void cbor_stream_reset(cbor_stream_decoder_t *decoder)
 {
+	assert(decoder != NULL);
+
+	if (decoder == NULL) {
+		return;
+	}
+
 	cbor_stream_callback_t cb  = decoder->callback;
 	void                  *arg = decoder->callback_arg;
 	memset(decoder, 0, sizeof(*decoder));

--- a/src/stream.c
+++ b/src/stream.c
@@ -576,7 +576,6 @@ void cbor_stream_init(cbor_stream_decoder_t *decoder,
 		cbor_stream_callback_t callback, void *arg)
 {
 	assert(decoder != NULL);
-	assert(callback != NULL);
 
 	if (decoder == NULL) {
 		return;

--- a/src/stream.c
+++ b/src/stream.c
@@ -284,6 +284,11 @@ static cbor_error_t handle_break(cbor_stream_decoder_t *d)
 		return CBOR_ILLEGAL;
 	}
 
+	if (d->stack[d->depth - 1].type == CBOR_ITEM_MAP &&
+			!d->stack[d->depth - 1].is_key) {
+		return CBOR_ILLEGAL;
+	}
+
 	/* indefinite container terminated by BREAK */
 	cbor_error_t err = emit_container_end(d);
 	if (err != CBOR_SUCCESS) {
@@ -647,7 +652,8 @@ cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder)
 
 	if (decoder->state != STREAM_STATE_IDLE || decoder->depth > 0 ||
 			decoder->in_indef_str ||
-			decoder->following_bytes_read > 0) {
+			decoder->following_bytes_read > 0 ||
+			decoder->has_pending_tag) {
 		return CBOR_NEED_MORE;
 	}
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,0 +1,629 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "cbor/stream.h"
+#include "cbor/ieee754.h"
+#include <string.h>
+
+enum stream_state {
+	STREAM_STATE_IDLE    = 0,
+	STREAM_STATE_LENGTH  = 1,
+	STREAM_STATE_PAYLOAD = 2,
+	STREAM_STATE_ERROR   = 3,
+};
+
+/* ---------- event helpers ---------- */
+
+static void build_event(cbor_stream_decoder_t *d,
+		cbor_stream_event_type_t type, cbor_stream_event_t *event)
+{
+	event->type = type;
+	event->depth = d->depth;
+	event->is_map_key = (d->depth > 0) &&
+		(d->stack[d->depth - 1].type == CBOR_ITEM_MAP) &&
+		d->stack[d->depth - 1].is_key;
+	event->has_tag = d->has_pending_tag;
+	event->tag     = d->pending_tag;
+	d->has_pending_tag = false;
+}
+
+static cbor_error_t invoke_cb(cbor_stream_decoder_t *d,
+		const cbor_stream_event_t *event, const cbor_stream_data_t *data)
+{
+	if (!d->callback(event, data, d->callback_arg)) {
+		d->error = CBOR_ABORTED;
+		d->state = STREAM_STATE_ERROR;
+		return CBOR_ABORTED;
+	}
+	return CBOR_SUCCESS;
+}
+
+/* ---------- container helpers ---------- */
+
+static cbor_error_t emit_container_end(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_event_type_t type;
+
+	d->depth--;
+	type = (d->stack[d->depth].type == CBOR_ITEM_ARRAY)
+		? CBOR_STREAM_EVENT_ARRAY_END : CBOR_STREAM_EVENT_MAP_END;
+	build_event(d, type, &event);
+	return invoke_cb(d, &event, NULL);
+}
+
+static cbor_error_t after_item(cbor_stream_decoder_t *d)
+{
+	while (d->depth > 0) {
+		cbor_stream_frame_t *f = &d->stack[d->depth - 1];
+
+		if (f->type == CBOR_ITEM_MAP) {
+			f->is_key = !f->is_key;
+		}
+
+		if (f->count < 0) {
+			/* indefinite: wait for BREAK */
+			break;
+		}
+
+		f->count--;
+		if (f->count > 0) {
+			break;
+		}
+
+		cbor_error_t err = emit_container_end(d);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		/* continue to cascade up */
+	}
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t push_container(cbor_stream_decoder_t *d,
+		cbor_item_data_t type, int64_t count)
+{
+	if (d->depth >= CBOR_RECURSION_MAX_LEVEL) {
+		return CBOR_EXCESSIVE;
+	}
+
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data;
+	cbor_stream_event_type_t evtype = (type == CBOR_ITEM_ARRAY)
+		? CBOR_STREAM_EVENT_ARRAY_START : CBOR_STREAM_EVENT_MAP_START;
+
+	build_event(d, evtype, &event);
+	data.container.size = count;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+
+	cbor_stream_frame_t *f = &d->stack[d->depth];
+	f->type   = type;
+	f->count  = count;
+	f->is_key = (type == CBOR_ITEM_MAP);
+	d->depth++;
+
+	if (count == 0) {
+		err = emit_container_end(d);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		return after_item(d);
+	}
+
+	return CBOR_SUCCESS;
+}
+
+/* ---------- length decoding ---------- */
+
+static uint64_t decode_length_buf(const cbor_stream_decoder_t *d)
+{
+	uint64_t val = 0;
+	for (uint8_t i = 0; i < d->following_bytes; i++) {
+		val = (val << 8) | d->length_buf[i];
+	}
+	return val;
+}
+
+static uint64_t get_item_value(const cbor_stream_decoder_t *d)
+{
+	if (d->following_bytes == 0) {
+		return d->additional_info;
+	}
+	return decode_length_buf(d);
+}
+
+/* ---------- float decoding ---------- */
+
+static double decode_float_value(const cbor_stream_decoder_t *d)
+{
+	uint64_t raw = decode_length_buf(d);
+
+	if (d->following_bytes == 2) {
+		return ieee754_convert_half_to_double((uint16_t)raw);
+	} else if (d->following_bytes == 4) {
+		uint32_t u32 = (uint32_t)raw;
+		float f;
+		memcpy(&f, &u32, 4);
+		return (double)f;
+	} else {
+		double dbl;
+		memcpy(&dbl, &raw, 8);
+		return dbl;
+	}
+}
+
+/* ---------- item emitters ---------- */
+
+static cbor_error_t emit_uint(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data;
+
+	build_event(d, CBOR_STREAM_EVENT_UINT, &event);
+	data.uint = get_item_value(d);
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_int(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data;
+	uint64_t raw = get_item_value(d);
+
+	build_event(d, CBOR_STREAM_EVENT_INT, &event);
+	data.sint = (int64_t)(~raw);
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_str_chunk(cbor_stream_decoder_t *d,
+		cbor_stream_event_type_t type,
+		const uint8_t *ptr, size_t len, bool first, bool last)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data;
+
+	build_event(d, type, &event);
+	data.str.ptr   = ptr;
+	data.str.len   = len;
+	data.str.total = d->payload_total;
+	data.str.first = first;
+	data.str.last  = last;
+
+	return invoke_cb(d, &event, &data);
+}
+
+static cbor_error_t emit_simple(cbor_stream_decoder_t *d, uint8_t val)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+	cbor_error_t        err;
+
+	switch (val) {
+	case 20:
+		build_event(d, CBOR_STREAM_EVENT_BOOL, &event);
+		data.boolean = false;
+		break;
+	case 21:
+		build_event(d, CBOR_STREAM_EVENT_BOOL, &event);
+		data.boolean = true;
+		break;
+	case 22:
+		build_event(d, CBOR_STREAM_EVENT_NULL, &event);
+		break;
+	case 23:
+		build_event(d, CBOR_STREAM_EVENT_UNDEFINED, &event);
+		break;
+	default:
+		build_event(d, CBOR_STREAM_EVENT_SIMPLE, &event);
+		data.simple = val;
+		break;
+	}
+
+	err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_float(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data;
+
+	build_event(d, CBOR_STREAM_EVENT_FLOAT, &event);
+	data.flt = decode_float_value(d);
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+/* ---------- BREAK handling ---------- */
+
+static cbor_error_t handle_break(cbor_stream_decoder_t *d)
+{
+	if (d->in_indef_str) {
+		cbor_stream_event_type_t type = (d->indef_str_major == 2)
+			? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+		cbor_error_t err = emit_str_chunk(d, type, NULL, 0,
+				d->payload_first_chunk, true);
+		d->in_indef_str = false;
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		return after_item(d);
+	}
+
+	if (d->depth == 0 || d->stack[d->depth - 1].count >= 0) {
+		return CBOR_ILLEGAL;
+	}
+
+	/* indefinite container terminated by BREAK */
+	cbor_error_t err = emit_container_end(d);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+/* ---------- process complete initial byte (no following bytes) ---------- */
+
+static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
+{
+	cbor_error_t err;
+
+	switch (d->major_type) {
+	case 0: /* unsigned integer */
+		return emit_uint(d);
+
+	case 1: /* negative integer */
+		return emit_int(d);
+
+	case 2: /* byte string, length in additional_info */
+	case 3: /* text string, length in additional_info */ {
+		cbor_stream_event_type_t stype = (d->major_type == 2)
+			? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+		uint64_t slen = (uint64_t)d->additional_info;
+
+		if (!d->in_indef_str) {
+			d->payload_total       = (int64_t)slen;
+			d->payload_first_chunk = true;
+		}
+
+		if (slen == 0) {
+			bool first = d->in_indef_str ? d->payload_first_chunk : true;
+			bool last  = !d->in_indef_str;
+			d->payload_first_chunk = false;
+			err = emit_str_chunk(d, stype, NULL, 0, first, last);
+			if (err != CBOR_SUCCESS) {
+				return err;
+			}
+			if (!d->in_indef_str) {
+				return after_item(d);
+			}
+			return CBOR_SUCCESS;
+		}
+
+		d->payload_remaining = (int64_t)slen;
+		d->state = STREAM_STATE_PAYLOAD;
+		return CBOR_SUCCESS;
+	}
+
+	case 4: /* definite array */
+		return push_container(d, CBOR_ITEM_ARRAY,
+				(int64_t)d->additional_info);
+
+	case 5: /* definite map */
+		return push_container(d, CBOR_ITEM_MAP,
+				(int64_t)(d->additional_info * 2));
+
+	case 6: /* tag, value in additional_info */
+		if (d->has_pending_tag) {
+			return CBOR_EXCESSIVE;
+		}
+		d->has_pending_tag = true;
+		d->pending_tag     = (uint64_t)d->additional_info;
+		return CBOR_SUCCESS;
+
+	case 7: /* simple value (additional_info 0-23) */
+		/* additional_info >= 24 has following_bytes > 0, handled elsewhere;
+		 * additional_info == 31 (BREAK) is caught by handle_indefinite() */
+		return emit_simple(d, d->additional_info);
+
+	default:
+		return CBOR_ILLEGAL;
+	}
+}
+
+/* ---------- process complete length bytes ---------- */
+
+static cbor_error_t process_string_length(cbor_stream_decoder_t *d)
+{
+	uint64_t len = decode_length_buf(d);
+	cbor_stream_event_type_t type = (d->major_type == 2)
+		? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+
+	/* For indefinite-string sub-chunks keep payload_total as -1 */
+	if (!d->in_indef_str) {
+		d->payload_total = (int64_t)len;
+	}
+
+	if (len == 0) {
+		bool first = d->in_indef_str ? d->payload_first_chunk : true;
+		bool last  = !d->in_indef_str;
+		d->payload_first_chunk = false;
+		cbor_error_t err = emit_str_chunk(d, type, NULL, 0, first, last);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		if (!d->in_indef_str) {
+			return after_item(d);
+		}
+		return CBOR_SUCCESS;
+	}
+
+	d->payload_remaining   = (int64_t)len;
+	d->payload_first_chunk = d->in_indef_str ? d->payload_first_chunk : true;
+	d->state = STREAM_STATE_PAYLOAD;
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t process_container_length(cbor_stream_decoder_t *d)
+{
+	uint64_t n = decode_length_buf(d);
+	cbor_item_data_t type = (d->major_type == 4)
+		? CBOR_ITEM_ARRAY : CBOR_ITEM_MAP;
+	int64_t count = (type == CBOR_ITEM_MAP) ? (int64_t)(n * 2) : (int64_t)n;
+	return push_container(d, type, count);
+}
+
+static cbor_error_t process_tag_length(cbor_stream_decoder_t *d)
+{
+	if (d->has_pending_tag) {
+		return CBOR_EXCESSIVE;
+	}
+	d->has_pending_tag = true;
+	d->pending_tag     = decode_length_buf(d);
+	d->state = STREAM_STATE_IDLE;
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t process_float_simple_length(cbor_stream_decoder_t *d)
+{
+	if (d->following_bytes == 1) {
+		/* 1 following byte → simple value */
+		return emit_simple(d, d->length_buf[0]);
+	}
+	return emit_float(d);
+}
+
+static cbor_error_t process_length_complete(cbor_stream_decoder_t *d)
+{
+	d->state = STREAM_STATE_IDLE;
+
+	switch (d->major_type) {
+	case 0: return emit_uint(d);
+	case 1: return emit_int(d);
+	case 2: /* fall-through */
+	case 3: return process_string_length(d);
+	case 4: /* fall-through */
+	case 5: return process_container_length(d);
+	case 6: return process_tag_length(d);
+	case 7: return process_float_simple_length(d);
+	default: return CBOR_ILLEGAL;
+	}
+}
+
+/* ---------- indefinite-length starters ---------- */
+
+static cbor_error_t handle_indefinite(cbor_stream_decoder_t *d)
+{
+	switch (d->major_type) {
+	case 2: /* indefinite byte string */
+	case 3: /* indefinite text string */
+		if (d->in_indef_str) {
+			return CBOR_ILLEGAL; /* no nesting of indef strings */
+		}
+		d->in_indef_str        = true;
+		d->indef_str_major     = d->major_type;
+		d->payload_first_chunk = true;
+		d->payload_total       = -1;
+		d->state = STREAM_STATE_IDLE;
+		return CBOR_SUCCESS;
+
+	case 4: /* indefinite array */
+		return push_container(d, CBOR_ITEM_ARRAY, -1);
+
+	case 5: /* indefinite map */
+		return push_container(d, CBOR_ITEM_MAP, -1);
+
+	case 7: /* BREAK */
+		return handle_break(d);
+
+	default:
+		return CBOR_ILLEGAL;
+	}
+}
+
+/* ---------- initial byte parsing ---------- */
+
+static cbor_error_t process_initial_byte(cbor_stream_decoder_t *d, uint8_t b)
+{
+	d->major_type      = b >> 5;
+	d->additional_info = b & 0x1fu;
+	d->following_bytes = cbor_get_following_bytes(d->additional_info);
+
+	if (d->following_bytes == (uint8_t)CBOR_RESERVED_VALUE) {
+		return CBOR_ILLEGAL;
+	}
+
+	if (d->in_indef_str) {
+		/* inside indefinite string: only BREAK or same-major sub-chunks */
+		if (b == 0xff) {
+			return handle_break(d);
+		}
+		if (d->major_type != d->indef_str_major) {
+			return CBOR_ILLEGAL;
+		}
+		if (d->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
+			return CBOR_ILLEGAL; /* no nested indefinite */
+		}
+	}
+
+	if (d->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
+		return handle_indefinite(d);
+	}
+
+	if (d->following_bytes == 0) {
+		return process_immediate(d);
+	}
+
+	/* need to read following_bytes bytes */
+	d->following_bytes_read = 0;
+	memset(d->length_buf, 0, sizeof(d->length_buf));
+	d->state = STREAM_STATE_LENGTH;
+	return CBOR_SUCCESS;
+}
+
+/* ---------- payload streaming ---------- */
+
+static cbor_error_t consume_payload(cbor_stream_decoder_t *d,
+		const uint8_t **p, size_t *remaining)
+{
+	size_t avail = (size_t)d->payload_remaining;
+	if (avail > *remaining) {
+		avail = *remaining;
+	}
+
+	cbor_stream_event_type_t type = (d->major_type == 2)
+		? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+	bool last = ((int64_t)avail == d->payload_remaining) && !d->in_indef_str;
+
+	cbor_error_t err = emit_str_chunk(d, type, *p, avail,
+			d->payload_first_chunk, last);
+	d->payload_first_chunk = false;
+
+	*p               += avail;
+	*remaining       -= avail;
+	d->payload_remaining -= (int64_t)avail;
+
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+
+	if (d->payload_remaining > 0) {
+		return CBOR_SUCCESS; /* still in PAYLOAD state */
+	}
+
+	d->state = STREAM_STATE_IDLE;
+
+	if (!d->in_indef_str) {
+		return after_item(d);
+	}
+	/* sub-chunk done; stay in in_indef_str mode */
+	return CBOR_SUCCESS;
+}
+
+/* ---------- public API ---------- */
+
+void cbor_stream_init(cbor_stream_decoder_t *decoder,
+		cbor_stream_callback_t callback, void *arg)
+{
+	memset(decoder, 0, sizeof(*decoder));
+	decoder->callback     = callback;
+	decoder->callback_arg = arg;
+	decoder->state        = STREAM_STATE_IDLE;
+}
+
+cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
+		const void *data, size_t len)
+{
+	if (decoder->state == STREAM_STATE_ERROR) {
+		return decoder->error;
+	}
+
+	const uint8_t *p         = (const uint8_t *)data;
+	size_t         remaining  = len;
+	cbor_error_t   err        = CBOR_SUCCESS;
+
+	while (remaining > 0) {
+		switch (decoder->state) {
+		case STREAM_STATE_IDLE:
+			err = process_initial_byte(decoder, *p);
+			p++;
+			remaining--;
+			break;
+
+		case STREAM_STATE_LENGTH:
+			decoder->length_buf[decoder->following_bytes_read++] = *p;
+			p++;
+			remaining--;
+			if (decoder->following_bytes_read == decoder->following_bytes) {
+				err = process_length_complete(decoder);
+			}
+			break;
+
+		case STREAM_STATE_PAYLOAD:
+			err = consume_payload(decoder, &p, &remaining);
+			break;
+
+		case STREAM_STATE_ERROR:
+			return decoder->error;
+		default:
+			return CBOR_ILLEGAL;
+		}
+
+		if (err != CBOR_SUCCESS) {
+			decoder->error = err;
+			decoder->state = STREAM_STATE_ERROR;
+			return err;
+		}
+	}
+
+	return CBOR_SUCCESS;
+}
+
+cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder)
+{
+	if (decoder->state == STREAM_STATE_ERROR) {
+		return decoder->error;
+	}
+
+	if (decoder->state != STREAM_STATE_IDLE || decoder->depth > 0 ||
+			decoder->in_indef_str ||
+			decoder->following_bytes_read > 0) {
+		return CBOR_NEED_MORE;
+	}
+
+	return CBOR_SUCCESS;
+}
+
+void cbor_stream_reset(cbor_stream_decoder_t *decoder)
+{
+	cbor_stream_callback_t cb  = decoder->callback;
+	void                  *arg = decoder->callback_arg;
+	memset(decoder, 0, sizeof(*decoder));
+	decoder->callback     = cb;
+	decoder->callback_arg = arg;
+	decoder->state        = STREAM_STATE_IDLE;
+}

--- a/src/stream.c
+++ b/src/stream.c
@@ -105,7 +105,8 @@ static cbor_error_t push_container(cbor_stream_decoder_t *d,
 		? CBOR_STREAM_EVENT_ARRAY_START : CBOR_STREAM_EVENT_MAP_START;
 
 	build_event(d, evtype, &event);
-	data.container.size = count;
+	data.container.size = (type == CBOR_ITEM_MAP && count >= 0)
+		? (count / 2) : count;
 
 	cbor_error_t err = invoke_cb(d, &event, &data);
 	if (err != CBOR_SUCCESS) {
@@ -433,19 +434,25 @@ static cbor_error_t process_float_simple_length(cbor_stream_decoder_t *d)
 
 static cbor_error_t process_length_complete(cbor_stream_decoder_t *d)
 {
+	cbor_error_t err;
+
 	d->state = STREAM_STATE_IDLE;
 
 	switch (d->major_type) {
-	case 0: return emit_uint(d);
-	case 1: return emit_int(d);
+	case 0: err = emit_uint(d); break;
+	case 1: err = emit_int(d); break;
 	case 2: /* fall-through */
-	case 3: return process_string_length(d);
+	case 3: err = process_string_length(d); break;
 	case 4: /* fall-through */
-	case 5: return process_container_length(d);
-	case 6: return process_tag_length(d);
-	case 7: return process_float_simple_length(d);
-	default: return CBOR_ILLEGAL;
+	case 5: err = process_container_length(d); break;
+	case 6: err = process_tag_length(d); break;
+	case 7: err = process_float_simple_length(d); break;
+	default: err = CBOR_ILLEGAL; break;
 	}
+
+	d->following_bytes = 0;
+	d->following_bytes_read = 0;
+	return err;
 }
 
 static cbor_error_t handle_indefinite(cbor_stream_decoder_t *d)

--- a/src/stream.c
+++ b/src/stream.c
@@ -538,9 +538,9 @@ static cbor_error_t consume_payload(cbor_stream_decoder_t *d,
 		return CBOR_INVALID;
 	}
 
-	size_t avail = (size_t)d->payload_remaining;
-	if (avail > *remaining) {
-		avail = *remaining;
+	size_t avail = *remaining;
+	if (d->payload_remaining < (int64_t)avail) {
+		avail = (size_t)d->payload_remaining;
 	}
 
 	cbor_stream_event_type_t type = (d->major_type == 2)

--- a/src/stream.c
+++ b/src/stream.c
@@ -100,7 +100,7 @@ static cbor_error_t push_container(cbor_stream_decoder_t *d,
 	}
 
 	cbor_stream_event_t event;
-	cbor_stream_data_t  data;
+	cbor_stream_data_t  data = {0};
 	cbor_stream_event_type_t evtype = (type == CBOR_ITEM_ARRAY)
 		? CBOR_STREAM_EVENT_ARRAY_START : CBOR_STREAM_EVENT_MAP_START;
 
@@ -168,7 +168,7 @@ static double decode_float_value(const cbor_stream_decoder_t *d)
 static cbor_error_t emit_uint(cbor_stream_decoder_t *d)
 {
 	cbor_stream_event_t event;
-	cbor_stream_data_t  data;
+	cbor_stream_data_t  data = {0};
 
 	build_event(d, CBOR_STREAM_EVENT_UINT, &event);
 	data.uint = get_item_value(d);
@@ -183,7 +183,7 @@ static cbor_error_t emit_uint(cbor_stream_decoder_t *d)
 static cbor_error_t emit_int(cbor_stream_decoder_t *d)
 {
 	cbor_stream_event_t event;
-	cbor_stream_data_t  data;
+	cbor_stream_data_t  data = {0};
 	uint64_t raw = get_item_value(d);
 
 	if (!can_fit_int64(raw)) {
@@ -205,7 +205,7 @@ static cbor_error_t emit_str_chunk(cbor_stream_decoder_t *d,
 		const uint8_t *ptr, size_t len, bool first, bool last)
 {
 	cbor_stream_event_t event;
-	cbor_stream_data_t  data;
+	cbor_stream_data_t  data = {0};
 
 	build_event(d, type, &event);
 	data.str.ptr   = ptr;
@@ -254,7 +254,7 @@ static cbor_error_t emit_simple(cbor_stream_decoder_t *d, uint8_t val)
 static cbor_error_t emit_float(cbor_stream_decoder_t *d)
 {
 	cbor_stream_event_t event;
-	cbor_stream_data_t  data;
+	cbor_stream_data_t  data = {0};
 
 	build_event(d, CBOR_STREAM_EVENT_FLOAT, &event);
 	data.flt = decode_float_value(d);
@@ -281,6 +281,10 @@ static cbor_error_t handle_break(cbor_stream_decoder_t *d)
 	}
 
 	if (d->depth == 0 || d->stack[d->depth - 1].count >= 0) {
+		return CBOR_ILLEGAL;
+	}
+
+	if (d->has_pending_tag) {
 		return CBOR_ILLEGAL;
 	}
 

--- a/tests/runners/stream.mk
+++ b/tests/runners/stream.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = stream
+
+SRC_FILES = \
+	../src/stream.c \
+	../src/common.c \
+	../src/ieee754.c \
+
+TEST_SRC_FILES = \
+	src/stream_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+
+include MakefileRunner.mk

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -229,6 +229,12 @@ TEST(Helper, iterate_ShouldVisitNoItems_WhenDefiniteMapIsEmpty)
 	LONGS_EQUAL(0, scalar_count);
 }
 
+TEST(Helper, stringifyError_ShouldDescribeStreamingErrors)
+{
+	STRCMP_EQUAL("need more data", cbor_stringify_error(CBOR_NEED_MORE));
+	STRCMP_EQUAL("aborted", cbor_stringify_error(CBOR_ABORTED));
+}
+
 TEST(Helper, iterate_ShouldVisitItemsInIndefiniteMap)
 {
 	/*

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -100,6 +100,10 @@ static bool record_cb(const cbor_stream_event_t *event,
 	case CBOR_STREAM_EVENT_MAP_START:
 		ev.container_size = data->container.size;
 		break;
+	case CBOR_STREAM_EVENT_ARRAY_END:
+	case CBOR_STREAM_EVENT_MAP_END:
+	case CBOR_STREAM_EVENT_NULL:
+	case CBOR_STREAM_EVENT_UNDEFINED:
 	default:
 		break;
 	}
@@ -430,11 +434,7 @@ TEST(StreamSimple, ShouldEmitFloat_WhenHalfPrecisionFloatGiven)
 
 TEST(StreamSimple, ShouldEmitFloat_WhenSinglePrecisionFloatGiven)
 {
-	/* 3.14f in single precision */
-	float f = 3.14f;
-	uint8_t raw[4];
-	memcpy(raw, &f, 4);
-	uint8_t msg[5] = { 0xfa, raw[3], raw[2], raw[1], raw[0] };
+	uint8_t msg[] = { 0xfa, 0x40, 0x48, 0xf5, 0xc3 };
 	feed_all(&decoder, msg, sizeof(msg));
 
 	LONGS_EQUAL(1, rec.count);
@@ -708,6 +708,45 @@ TEST(StreamError, ShouldReturnAborted_WhenCallbackReturnsFalse)
 
 	uint8_t msg[] = { 0x01, 0x02 };
 	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenCallbackIsNull)
+{
+	cbor_stream_init(&decoder, NULL, NULL);
+
+	uint8_t msg[] = { 0x01 };
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenNegativeIntegerExceedsInt64Range)
+{
+	uint8_t msg[] = {
+		0x3b, 0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenStringLengthExceedsInt64Range)
+{
+	uint8_t msg[] = {
+		0x7b, 0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenMapLengthOverflowsItemCount)
+{
+	uint8_t msg[] = {
+		0xbb, 0x40, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
 }
 
 TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidItem)

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -1059,17 +1059,20 @@ TEST(StreamLargePayload, ShouldMakeForwardProgress_WhenTextLengthExceeds32BitRan
 		0x00, 0x00, 0x00, 0x01,
 		0x00, 0x00, 0x00, 0x00,
 	};
-	uint8_t payload[] = { 'A' };
+	uint8_t payload1[] = { 'A' };
+	uint8_t payload2[] = { 'B' };
 
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, header, sizeof(header)));
-	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload, sizeof(payload)));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload1, sizeof(payload1)));
 
 	LONGS_EQUAL(1, guard.text_events);
 	CHECK(!guard.saw_zero_len);
 	LONGS_EQUAL(1, guard.last_len);
-	LONGS_EQUAL(2, decoder.state);
-	LONGLONGS_EQUAL(0x00000000ffffffffull,
-			(unsigned long long)decoder.payload_remaining);
-	CHECK(!decoder.payload_first_chunk);
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload2, sizeof(payload2)));
+	LONGS_EQUAL(2, guard.text_events);
+	CHECK(!guard.saw_zero_len);
+	LONGS_EQUAL(1, guard.last_len);
 	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
 }

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -919,3 +919,101 @@ TEST(StreamChunked, ShouldDecodeNestedMap_WhenComplexMessageGiven)
 	LONGS_EQUAL(1, rec.events[2].depth); /* array-start inside map value at depth 1 */
 	LONGS_EQUAL(2, rec.events[3].depth); /* items inside array at depth 2 */
 }
+
+/* ---------- TEST_GROUP: is_map_key on END events ---------- */
+
+TEST_GROUP(StreamMapKeyEnd)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamMapKeyEnd, ShouldReportArrayEndAsMapKey_WhenArrayIsMapKey)
+{
+	/*
+	 * {[1]: "v"}
+	 * 0xa1         map(1 pair)
+	 * 0x81 0x01    array(1): uint 1        <- map key
+	 * 0x61 0x76    text "v"                <- map value
+	 *
+	 * Expected events and is_map_key flags:
+	 *  [0] MAP_START      is_map_key=false (top-level)
+	 *  [1] ARRAY_START    is_map_key=true  (array is the key)
+	 *  [2] UINT(1)        is_map_key=false (inside array, not in a map)
+	 *  [3] ARRAY_END      is_map_key=true  (array was the key, its end should reflect that)
+	 *  [4] TEXT "v"       is_map_key=false (this is the value)
+	 *  [5] MAP_END        is_map_key=false
+	 */
+	uint8_t msg[] = { 0xa1, 0x81, 0x01, 0x61, 0x76 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+	LONGS_EQUAL(6, rec.count);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START,   rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[2].type);
+	CHECK(!rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END,   rec.events[3].type);
+	CHECK(rec.events[3].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT,        rec.events[4].type);
+	CHECK(!rec.events[4].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,     rec.events[5].type);
+}
+
+TEST(StreamMapKeyEnd, ShouldReportNestedMapEndAsMapKey_WhenNestedMapIsMapKey)
+{
+	/*
+	 * {{1:2}: "v"}
+	 * 0xa1               outer map(1 pair)
+	 * 0xa1 0x01 0x02     inner map{1:2}   <- outer map key
+	 * 0x61 0x76          text "v"         <- outer map value
+	 *
+	 * Expected events:
+	 *  [0] MAP_START (outer)   is_map_key=false
+	 *  [1] MAP_START (inner)   is_map_key=true  (inner map is the key)
+	 *  [2] UINT(1)             is_map_key=true  (key of inner map)
+	 *  [3] UINT(2)             is_map_key=false (value of inner map)
+	 *  [4] MAP_END (inner)     is_map_key=true  (inner map was the key)
+	 *  [5] TEXT "v"            is_map_key=false (outer map value)
+	 *  [6] MAP_END (outer)     is_map_key=false
+	 */
+	uint8_t msg[] = { 0xa1, 0xa1, 0x01, 0x02, 0x61, 0x76 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+	LONGS_EQUAL(7, rec.count);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,      rec.events[2].type);
+	CHECK(rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,      rec.events[3].type);
+	CHECK(!rec.events[3].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,   rec.events[4].type);
+	CHECK(rec.events[4].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT,      rec.events[5].type);
+	CHECK(!rec.events[5].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,   rec.events[6].type);
+}

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -1,0 +1,834 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "cbor/stream.h"
+#include <stdint.h>
+#include <string.h>
+
+/* ---------- helpers ---------- */
+
+struct RecordedEvent {
+	cbor_stream_event_type_t type;
+	uint8_t  depth;
+	bool     is_map_key;
+	bool     has_tag;
+	uint64_t tag;
+
+	/* scalar payloads */
+	uint64_t uint_val;
+	int64_t  sint_val;
+	double   flt_val;
+	bool     bool_val;
+	uint8_t  simple_val;
+
+	/* string fields */
+	uint8_t  str_buf[256];
+	size_t   str_len;
+	int64_t  str_total;
+	bool     str_first;
+	bool     str_last;
+
+	/* container size */
+	int64_t container_size;
+};
+
+static const int MAX_EVENTS = 64;
+
+struct Recorder {
+	RecordedEvent events[MAX_EVENTS];
+	int           count;
+	bool          abort_after_first;
+	int           abort_at;   /* abort when count reaches this value */
+};
+
+static bool record_cb(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg)
+{
+	Recorder *r = (Recorder *)arg;
+
+	if (r->abort_after_first && r->count >= r->abort_at) {
+		return false;
+	}
+
+	if (r->count >= MAX_EVENTS) {
+		return true;
+	}
+
+	RecordedEvent &ev = r->events[r->count++];
+	memset(&ev, 0, sizeof(ev));
+	ev.type       = event->type;
+	ev.depth      = event->depth;
+	ev.is_map_key = event->is_map_key;
+	ev.has_tag    = event->has_tag;
+	ev.tag        = event->tag;
+
+	if (!data) {
+		return true;
+	}
+
+	switch (event->type) {
+	case CBOR_STREAM_EVENT_UINT:
+		ev.uint_val = data->uint;
+		break;
+	case CBOR_STREAM_EVENT_INT:
+		ev.sint_val = data->sint;
+		break;
+	case CBOR_STREAM_EVENT_FLOAT:
+		ev.flt_val = data->flt;
+		break;
+	case CBOR_STREAM_EVENT_BOOL:
+		ev.bool_val = data->boolean;
+		break;
+	case CBOR_STREAM_EVENT_SIMPLE:
+		ev.simple_val = data->simple;
+		break;
+	case CBOR_STREAM_EVENT_BYTES:
+	case CBOR_STREAM_EVENT_TEXT:
+		ev.str_total = data->str.total;
+		ev.str_first = data->str.first;
+		ev.str_last  = data->str.last;
+		ev.str_len   = data->str.len;
+		if (data->str.ptr && data->str.len <= sizeof(ev.str_buf)) {
+			memcpy(ev.str_buf, data->str.ptr, data->str.len);
+		}
+		break;
+	case CBOR_STREAM_EVENT_ARRAY_START:
+	case CBOR_STREAM_EVENT_MAP_START:
+		ev.container_size = data->container.size;
+		break;
+	default:
+		break;
+	}
+
+	return true;
+}
+
+static void feed_all(cbor_stream_decoder_t *d, const uint8_t *buf, size_t len)
+{
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(d, buf, len));
+}
+
+/* Feed one byte at a time to stress the streaming logic */
+static void feed_byte_by_byte(cbor_stream_decoder_t *d,
+		const uint8_t *buf, size_t len)
+{
+	for (size_t i = 0; i < len; i++) {
+		LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(d, &buf[i], 1));
+	}
+}
+
+/* ---------- TEST_GROUP: Integers ---------- */
+
+TEST_GROUP(StreamInteger)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamInteger, ShouldEmitUint_WhenSmallUintGiven)
+{
+	uint8_t msg[] = { 0x05 }; /* uint 5 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGS_EQUAL(5, rec.events[0].uint_val);
+	LONGS_EQUAL(0, rec.events[0].depth);
+}
+
+TEST(StreamInteger, ShouldEmitUint_WhenOneByteLengthGiven)
+{
+	uint8_t msg[] = { 0x18, 0xff }; /* uint 255 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGS_EQUAL(255, rec.events[0].uint_val);
+}
+
+TEST(StreamInteger, ShouldEmitUint_WhenTwoByteLengthGiven)
+{
+	uint8_t msg[] = { 0x19, 0x01, 0x00 }; /* uint 256 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGS_EQUAL(256, rec.events[0].uint_val);
+}
+
+TEST(StreamInteger, ShouldEmitNegInt_WhenNegativeIntegerGiven)
+{
+	uint8_t msg[] = { 0x20 }; /* -1 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
+	LONGS_EQUAL(-1, rec.events[0].sint_val);
+}
+
+TEST(StreamInteger, ShouldEmitNegInt_WhenNeg100Given)
+{
+	uint8_t msg[] = { 0x38, 0x63 }; /* -100 = 0x38, 0x63 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
+	LONGS_EQUAL(-100, rec.events[0].sint_val);
+}
+
+TEST(StreamInteger, ShouldEmitMultipleUints_WhenFedByteByByte)
+{
+	uint8_t msg[] = { 0x01, 0x02, 0x03 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(3, rec.count);
+	LONGS_EQUAL(1, rec.events[0].uint_val);
+	LONGS_EQUAL(2, rec.events[1].uint_val);
+	LONGS_EQUAL(3, rec.events[2].uint_val);
+}
+
+/* ---------- TEST_GROUP: Strings ---------- */
+
+TEST_GROUP(StreamString)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamString, ShouldEmitEmptyTextString_WhenZeroLengthTextGiven)
+{
+	uint8_t msg[] = { 0x60 }; /* "" */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].str_len);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamString, ShouldEmitTextString_WhenShortTextGiven)
+{
+	/* "a" = 0x61, 0x61 */
+	uint8_t msg[] = { 0x61, 0x61 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
+	LONGS_EQUAL(1, rec.events[0].str_len);
+	LONGS_EQUAL('a', rec.events[0].str_buf[0]);
+	LONGS_EQUAL(1, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamString, ShouldEmitTextString_WhenFedByteByByte)
+{
+	/* "hello" */
+	uint8_t msg[] = { 0x65, 'h', 'e', 'l', 'l', 'o' };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	/* may arrive in multiple chunks; total content matters */
+	size_t total_len = 0;
+	for (int i = 0; i < rec.count; i++) {
+		total_len += rec.events[i].str_len;
+	}
+	LONGS_EQUAL(5, total_len);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[rec.count - 1].str_last);
+}
+
+TEST(StreamString, ShouldEmitByteString_WhenByteStringGiven)
+{
+	uint8_t msg[] = { 0x43, 0xAA, 0xBB, 0xCC }; /* h'aabbcc' */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(3, rec.events[0].str_len);
+	LONGS_EQUAL(0xAA, rec.events[0].str_buf[0]);
+}
+
+TEST(StreamString, ShouldEmitChunks_WhenPayloadSplitAcrossFeeds)
+{
+	/* 5-byte text "hello" split into 3+2 */
+	uint8_t header[] = { 0x65 };
+	uint8_t part1[]  = { 'h', 'e', 'l' };
+	uint8_t part2[]  = { 'l', 'o' };
+
+	feed_all(&decoder, header, sizeof(header));
+	feed_all(&decoder, part1, sizeof(part1));
+	feed_all(&decoder, part2, sizeof(part2));
+
+	/* At least first chunk has first=true, last chunk has last=true */
+	CHECK(rec.count >= 1);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[rec.count - 1].str_last);
+}
+
+/* ---------- TEST_GROUP: Indefinite Strings ---------- */
+
+TEST_GROUP(StreamIndefString)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamIndefString, ShouldEmitSingleBreakChunk_WhenEmptyIndefStringGiven)
+{
+	/* (_ ) = 0x5f 0xff */
+	uint8_t msg[] = { 0x5f, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].str_len);
+	LONGS_EQUAL(-1, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamIndefString, ShouldEmitSubChunkThenBreak_WhenIndefStringWithDataGiven)
+{
+	/* (_ h'0102') = 0x5f 0x42 0x01 0x02 0xff */
+	uint8_t msg[] = { 0x5f, 0x42, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+
+	/* first sub-chunk */
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(2, rec.events[0].str_len);
+	LONGS_EQUAL(0x01, rec.events[0].str_buf[0]);
+	LONGS_EQUAL(0x02, rec.events[0].str_buf[1]);
+	LONGS_EQUAL(-1, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(!rec.events[0].str_last);
+
+	/* BREAK chunk */
+	LONGS_EQUAL(0, rec.events[1].str_len);
+	CHECK(!rec.events[1].str_first);
+	CHECK(rec.events[1].str_last);
+}
+
+TEST(StreamIndefString, ShouldEmitTextChunks_WhenIndefTextStringGiven)
+{
+	/* (_ "fo" "o") = 0x7f 0x62 0x66 0x6f 0x61 0x6f 0xff */
+	uint8_t msg[] = { 0x7f, 0x62, 'f', 'o', 0x61, 'o', 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(3, rec.count);
+	for (int i = 0; i < 3; i++) {
+		LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[i].type);
+	}
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[2].str_last);
+	LONGS_EQUAL(0, rec.events[2].str_len); /* BREAK chunk */
+}
+
+TEST(StreamIndefString, ShouldReturnIllegal_WhenWrongMajorTypeInIndefString)
+{
+	/* 0x5f followed by a text string chunk instead of byte string */
+	uint8_t msg[] = { 0x5f, 0x61, 0x61 };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+/* ---------- TEST_GROUP: Simple / Float / Bool ---------- */
+
+TEST_GROUP(StreamSimple)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamSimple, ShouldEmitTrue_WhenTrueGiven)
+{
+	uint8_t msg[] = { 0xf5 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BOOL, rec.events[0].type);
+	CHECK(rec.events[0].bool_val);
+}
+
+TEST(StreamSimple, ShouldEmitFalse_WhenFalseGiven)
+{
+	uint8_t msg[] = { 0xf4 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BOOL, rec.events[0].type);
+	CHECK(!rec.events[0].bool_val);
+}
+
+TEST(StreamSimple, ShouldEmitNull_WhenNullGiven)
+{
+	uint8_t msg[] = { 0xf6 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_NULL, rec.events[0].type);
+}
+
+TEST(StreamSimple, ShouldEmitUndefined_WhenUndefinedGiven)
+{
+	uint8_t msg[] = { 0xf7 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UNDEFINED, rec.events[0].type);
+}
+
+TEST(StreamSimple, ShouldEmitSimple_WhenUnassignedSimpleValueGiven)
+{
+	uint8_t msg[] = { 0xe0 }; /* simple(0) */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_SIMPLE, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].simple_val);
+}
+
+TEST(StreamSimple, ShouldEmitFloat_WhenHalfPrecisionFloatGiven)
+{
+	/* 1.0 in half precision = 0xf9 0x3c 0x00 */
+	uint8_t msg[] = { 0xf9, 0x3c, 0x00 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_FLOAT, rec.events[0].type);
+	DOUBLES_EQUAL(1.0, rec.events[0].flt_val, 1e-6);
+}
+
+TEST(StreamSimple, ShouldEmitFloat_WhenSinglePrecisionFloatGiven)
+{
+	/* 3.14f in single precision */
+	float f = 3.14f;
+	uint8_t raw[4];
+	memcpy(raw, &f, 4);
+	uint8_t msg[5] = { 0xfa, raw[3], raw[2], raw[1], raw[0] };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_FLOAT, rec.events[0].type);
+	DOUBLES_EQUAL(3.14, rec.events[0].flt_val, 1e-5);
+}
+
+/* ---------- TEST_GROUP: Arrays ---------- */
+
+TEST_GROUP(StreamArray)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamArray, ShouldEmitStartEnd_WhenEmptyArrayGiven)
+{
+	uint8_t msg[] = { 0x80 }; /* [] */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].container_size);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[1].type);
+	LONGS_EQUAL(0, rec.events[1].depth);
+}
+
+TEST(StreamArray, ShouldEmitItemsWithCorrectDepth_WhenDefiniteArrayGiven)
+{
+	uint8_t msg[] = { 0x82, 0x01, 0x02 }; /* [1, 2] */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGS_EQUAL(2, rec.events[0].container_size);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	LONGS_EQUAL(1, rec.events[1].depth);
+	LONGS_EQUAL(1, rec.events[1].uint_val);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGS_EQUAL(2, rec.events[2].uint_val);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+	LONGS_EQUAL(0, rec.events[3].depth);
+}
+
+TEST(StreamArray, ShouldEmitNestedArrayEvents_WhenNestedArrayGiven)
+{
+	/* [[1]] */
+	uint8_t msg[] = { 0x81, 0x81, 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(5, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[1].type);
+	LONGS_EQUAL(1, rec.events[1].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGS_EQUAL(2, rec.events[2].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+	LONGS_EQUAL(1, rec.events[3].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[4].type);
+	LONGS_EQUAL(0, rec.events[4].depth);
+}
+
+TEST(StreamArray, ShouldEmitIndefiniteArray_WhenIndefArrayGiven)
+{
+	/* [_ 1, 2] = 0x9f 0x01 0x02 0xff */
+	uint8_t msg[] = { 0x9f, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(-1, rec.events[0].container_size);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+}
+
+TEST(StreamArray, ShouldEmitEvents_WhenArrayFedByteByByte)
+{
+	uint8_t msg[] = { 0x82, 0x01, 0x02 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+}
+
+/* ---------- TEST_GROUP: Maps ---------- */
+
+TEST_GROUP(StreamMap)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamMap, ShouldEmitStartEnd_WhenEmptyMapGiven)
+{
+	uint8_t msg[] = { 0xa0 }; /* {} */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[1].type);
+}
+
+TEST(StreamMap, ShouldSetIsMapKey_WhenInsideMap)
+{
+	/* {1: 2} = 0xa1 0x01 0x02 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x02 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	CHECK(!rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
+}
+
+TEST(StreamMap, ShouldEmitMultiplePairs_WhenMultiPairMapGiven)
+{
+	/* {1:2, 3:4} = 0xa2 0x01 0x02 0x03 0x04 */
+	uint8_t msg[] = { 0xa2, 0x01, 0x02, 0x03, 0x04 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(6, rec.count);
+	CHECK(rec.events[1].is_map_key);  /* key 1 */
+	CHECK(!rec.events[2].is_map_key); /* val 2 */
+	CHECK(rec.events[3].is_map_key);  /* key 3 */
+	CHECK(!rec.events[4].is_map_key); /* val 4 */
+}
+
+TEST(StreamMap, ShouldEmitIndefiniteMap_WhenIndefMapGiven)
+{
+	/* {_ 1:2} = 0xbf 0x01 0x02 0xff */
+	uint8_t msg[] = { 0xbf, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGS_EQUAL(-1, rec.events[0].container_size);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
+}
+
+/* ---------- TEST_GROUP: Tags ---------- */
+
+TEST_GROUP(StreamTag)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamTag, ShouldSetHasTag_WhenTaggedItemGiven)
+{
+	/* tag(1)(0) = 0xc1 0x00 */
+	uint8_t msg[] = { 0xc1, 0x00 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	CHECK(rec.events[0].has_tag);
+	LONGS_EQUAL(1, rec.events[0].tag);
+	LONGS_EQUAL(0, rec.events[0].uint_val);
+}
+
+TEST(StreamTag, ShouldSetHasTagOnStart_WhenTaggedArrayGiven)
+{
+	/* tag(0)([]) = 0xc0 0x80 */
+	uint8_t msg[] = { 0xc0, 0x80 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	CHECK(rec.events[0].has_tag);
+	LONGS_EQUAL(0, rec.events[0].tag);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[1].type);
+	CHECK(!rec.events[1].has_tag);
+}
+
+TEST(StreamTag, ShouldNotSetHasTag_WhenNoTagGiven)
+{
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	CHECK(!rec.events[0].has_tag);
+}
+
+TEST(StreamTag, ShouldReturnExcessive_WhenNestedTagsGiven)
+{
+	/* tag(1)(tag(2)(0)) = 0xc1 0xc2 0x00 */
+	uint8_t msg[] = { 0xc1, 0xc2, 0x00 };
+	LONGS_EQUAL(CBOR_EXCESSIVE, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+/* ---------- TEST_GROUP: Error Handling ---------- */
+
+TEST_GROUP(StreamError)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamError, ShouldReturnIllegal_WhenStrayBreakGiven)
+{
+	uint8_t msg[] = { 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnIllegal_WhenBreakInsideDefiniteArray)
+{
+	/* [_ (break)] pretending to be definite: 0x81 0xff */
+	uint8_t msg[] = { 0x81, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnIllegal_WhenReservedAdditionalInfoGiven)
+{
+	uint8_t msg[] = { 0x1c }; /* additional_info=28, reserved */
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldStickyError_WhenSubsequentFeedAfterError)
+{
+	uint8_t bad[] = { 0xff };
+	uint8_t good[] = { 0x01 };
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, bad, sizeof(bad)));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, good, sizeof(good)));
+	LONGS_EQUAL(0, rec.count); /* no extra events */
+}
+
+TEST(StreamError, ShouldReturnAborted_WhenCallbackReturnsFalse)
+{
+	rec.abort_after_first = true;
+	rec.abort_at = 1; /* abort after first event */
+
+	uint8_t msg[] = { 0x01, 0x02 };
+	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidItem)
+{
+	uint8_t msg[] = { 0x18 }; /* start of uint with 1-byte length, truncated */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidPayload)
+{
+	/* 3-byte text string, only header given */
+	uint8_t msg[] = { 0x63 };
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledInsideOpenArray)
+{
+	uint8_t msg[] = { 0x9f, 0x01 }; /* [_ 1, ... */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterCompleteItem)
+{
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+/* ---------- TEST_GROUP: Reset ---------- */
+
+TEST_GROUP(StreamReset)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamReset, ShouldDecodeAfterReset_WhenPreviouslyErrored)
+{
+	uint8_t bad[] = { 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, bad, sizeof(bad)));
+
+	cbor_stream_reset(&decoder);
+	rec.count = 0;
+
+	uint8_t good[] = { 0x05 };
+	feed_all(&decoder, good, sizeof(good));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGS_EQUAL(5, rec.events[0].uint_val);
+}
+
+TEST(StreamReset, ShouldPreserveCallback_WhenResetCalled)
+{
+	cbor_stream_reset(&decoder);
+
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+}
+
+/* ---------- TEST_GROUP: Chunked feeds ---------- */
+
+TEST_GROUP(StreamChunked)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamChunked, ShouldDecodeCorrectly_WhenMapFedInChunks)
+{
+	/* {1: "hi"} = 0xa1 0x01 0x62 0x68 0x69 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x62, 0x68, 0x69 };
+
+	/* feed 2 bytes, then 3 bytes */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, 2));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg + 2, 3));
+
+	/* MAP_START, key=1 (uint), value="hi" (text), MAP_END */
+	int evt = 0;
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[evt++].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[evt].type);
+	CHECK(rec.events[evt++].is_map_key);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[evt].type);
+	CHECK(!rec.events[evt++].is_map_key);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[evt++].type);
+	LONGS_EQUAL(evt, rec.count);
+}
+
+TEST(StreamChunked, ShouldDecodeNestedMap_WhenComplexMessageGiven)
+{
+	/* {1: [2, 3]} = 0xa1 0x01 0x82 0x02 0x03 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x82, 0x02, 0x03 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	/* MAP_START, key(uint 1), ARRAY_START, uint 2, uint 3, ARRAY_END, MAP_END */
+	LONGS_EQUAL(7, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START,   rec.events[0].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[1].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[2].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[3].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[4].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END,   rec.events[5].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,     rec.events[6].type);
+
+	LONGS_EQUAL(1, rec.events[2].depth); /* array-start inside map value at depth 1 */
+	LONGS_EQUAL(2, rec.events[3].depth); /* items inside array at depth 2 */
+}

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -575,6 +575,15 @@ TEST(StreamMap, ShouldSetIsMapKey_WhenInsideMap)
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
 }
 
+TEST(StreamMap, ShouldReportPairCount_WhenDefiniteMapGiven)
+{
+	uint8_t msg[] = { 0xa2, 0x01, 0x02, 0x03, 0x04 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGS_EQUAL(2, rec.events[0].container_size);
+}
+
 TEST(StreamMap, ShouldEmitMultiplePairs_WhenMultiPairMapGiven)
 {
 	/* {1:2, 3:4} = 0xa2 0x01 0x02 0x03 0x04 */
@@ -771,10 +780,28 @@ TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledInsideOpenArray)
 	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
 }
 
+TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterCompleteLengthEncodedUint)
+{
+	uint8_t msg[] = { 0x18, 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
 TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterCompleteItem)
 {
 	uint8_t msg[] = { 0x01 };
 	feed_all(&decoder, msg, sizeof(msg));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldTreatZeroLengthFeedAsNoOp)
+{
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, NULL, 0));
+
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
 }
 

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -45,6 +45,12 @@ struct Recorder {
 	int           abort_at;   /* abort when count reaches this value */
 };
 
+struct ZeroLengthGuard {
+	int    text_events;
+	size_t last_len;
+	bool   saw_zero_len;
+};
+
 static bool record_cb(const cbor_stream_event_t *event,
 		const cbor_stream_data_t *data, void *arg)
 {
@@ -109,6 +115,22 @@ static bool record_cb(const cbor_stream_event_t *event,
 	}
 
 	return true;
+}
+
+static bool reject_zero_length_text_cb(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg)
+{
+	ZeroLengthGuard *guard = (ZeroLengthGuard *)arg;
+
+	if (event->type != CBOR_STREAM_EVENT_TEXT || data == NULL) {
+		return true;
+	}
+
+	guard->text_events++;
+	guard->last_len = data->str.len;
+	guard->saw_zero_len = (data->str.len == 0);
+
+	return !guard->saw_zero_len;
 }
 
 static void feed_all(cbor_stream_decoder_t *d, const uint8_t *buf, size_t len)
@@ -1016,4 +1038,38 @@ TEST(StreamMapKeyEnd, ShouldReportNestedMapEndAsMapKey_WhenNestedMapIsMapKey)
 	CHECK(!rec.events[5].is_map_key);
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,   rec.events[6].type);
+}
+
+TEST_GROUP(StreamLargePayload)
+{
+	cbor_stream_decoder_t decoder;
+	ZeroLengthGuard       guard;
+
+	void setup()
+	{
+		memset(&guard, 0, sizeof(guard));
+		cbor_stream_init(&decoder, reject_zero_length_text_cb, &guard);
+	}
+};
+
+TEST(StreamLargePayload, ShouldMakeForwardProgress_WhenTextLengthExceeds32BitRange)
+{
+	uint8_t header[] = {
+		0x7b,
+		0x00, 0x00, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x00,
+	};
+	uint8_t payload[] = { 'A' };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, header, sizeof(header)));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload, sizeof(payload)));
+
+	LONGS_EQUAL(1, guard.text_events);
+	CHECK(!guard.saw_zero_len);
+	LONGS_EQUAL(1, guard.last_len);
+	LONGS_EQUAL(2, decoder.state);
+	LONGLONGS_EQUAL(0x00000000ffffffffull,
+			(unsigned long long)decoder.payload_remaining);
+	CHECK(!decoder.payload_first_chunk);
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
 }

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -700,6 +700,14 @@ TEST(StreamError, ShouldReturnIllegal_WhenBreakInsideDefiniteArray)
 	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
 }
 
+TEST(StreamError, ShouldReturnIllegal_WhenBreakFollowsPendingTagInIndefiniteArray)
+{
+	uint8_t msg[] = { 0x9f, 0xc0, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+}
+
 TEST(StreamError, ShouldReturnIllegal_WhenReservedAdditionalInfoGiven)
 {
 	uint8_t msg[] = { 0x1c }; /* additional_info=28, reserved */

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -609,6 +609,12 @@ TEST(StreamMap, ShouldEmitIndefiniteMap_WhenIndefMapGiven)
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
 }
 
+TEST(StreamMap, ShouldReturnIllegal_WhenBreakFollowsOnlyMapKey)
+{
+	uint8_t msg[] = { 0xbf, 0x01, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
 /* ---------- TEST_GROUP: Tags ---------- */
 
 TEST_GROUP(StreamTag)
@@ -776,6 +782,13 @@ TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidPayload)
 TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledInsideOpenArray)
 {
 	uint8_t msg[] = { 0x9f, 0x01 }; /* [_ 1, ... */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledAfterBareTag)
+{
+	uint8_t msg[] = { 0xc0 };
 	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
 	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
 }

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -168,7 +168,7 @@ TEST(StreamInteger, ShouldEmitUint_WhenSmallUintGiven)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
-	LONGS_EQUAL(5, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(5ull, rec.events[0].uint_val);
 	LONGS_EQUAL(0, rec.events[0].depth);
 }
 
@@ -179,7 +179,7 @@ TEST(StreamInteger, ShouldEmitUint_WhenOneByteLengthGiven)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
-	LONGS_EQUAL(255, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(255ull, rec.events[0].uint_val);
 }
 
 TEST(StreamInteger, ShouldEmitUint_WhenTwoByteLengthGiven)
@@ -189,7 +189,7 @@ TEST(StreamInteger, ShouldEmitUint_WhenTwoByteLengthGiven)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
-	LONGS_EQUAL(256, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(256ull, rec.events[0].uint_val);
 }
 
 TEST(StreamInteger, ShouldEmitNegInt_WhenNegativeIntegerGiven)
@@ -199,7 +199,7 @@ TEST(StreamInteger, ShouldEmitNegInt_WhenNegativeIntegerGiven)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
-	LONGS_EQUAL(-1, rec.events[0].sint_val);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].sint_val);
 }
 
 TEST(StreamInteger, ShouldEmitNegInt_WhenNeg100Given)
@@ -209,7 +209,7 @@ TEST(StreamInteger, ShouldEmitNegInt_WhenNeg100Given)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
-	LONGS_EQUAL(-100, rec.events[0].sint_val);
+	LONGLONGS_EQUAL(-100ll, rec.events[0].sint_val);
 }
 
 TEST(StreamInteger, ShouldEmitMultipleUints_WhenFedByteByByte)
@@ -218,9 +218,9 @@ TEST(StreamInteger, ShouldEmitMultipleUints_WhenFedByteByByte)
 	feed_byte_by_byte(&decoder, msg, sizeof(msg));
 
 	LONGS_EQUAL(3, rec.count);
-	LONGS_EQUAL(1, rec.events[0].uint_val);
-	LONGS_EQUAL(2, rec.events[1].uint_val);
-	LONGS_EQUAL(3, rec.events[2].uint_val);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(2ull, rec.events[1].uint_val);
+	LONGLONGS_EQUAL(3ull, rec.events[2].uint_val);
 }
 
 /* ---------- TEST_GROUP: Strings ---------- */
@@ -259,7 +259,7 @@ TEST(StreamString, ShouldEmitTextString_WhenShortTextGiven)
 	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
 	LONGS_EQUAL(1, rec.events[0].str_len);
 	LONGS_EQUAL('a', rec.events[0].str_buf[0]);
-	LONGS_EQUAL(1, rec.events[0].str_total);
+	LONGLONGS_EQUAL(1ll, rec.events[0].str_total);
 	CHECK(rec.events[0].str_first);
 	CHECK(rec.events[0].str_last);
 }
@@ -331,7 +331,7 @@ TEST(StreamIndefString, ShouldEmitSingleBreakChunk_WhenEmptyIndefStringGiven)
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
 	LONGS_EQUAL(0, rec.events[0].str_len);
-	LONGS_EQUAL(-1, rec.events[0].str_total);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].str_total);
 	CHECK(rec.events[0].str_first);
 	CHECK(rec.events[0].str_last);
 }
@@ -349,7 +349,7 @@ TEST(StreamIndefString, ShouldEmitSubChunkThenBreak_WhenIndefStringWithDataGiven
 	LONGS_EQUAL(2, rec.events[0].str_len);
 	LONGS_EQUAL(0x01, rec.events[0].str_buf[0]);
 	LONGS_EQUAL(0x02, rec.events[0].str_buf[1]);
-	LONGS_EQUAL(-1, rec.events[0].str_total);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].str_total);
 	CHECK(rec.events[0].str_first);
 	CHECK(!rec.events[0].str_last);
 
@@ -485,7 +485,7 @@ TEST(StreamArray, ShouldEmitStartEnd_WhenEmptyArrayGiven)
 
 	LONGS_EQUAL(2, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
-	LONGS_EQUAL(0, rec.events[0].container_size);
+	LONGLONGS_EQUAL(0ll, rec.events[0].container_size);
 	LONGS_EQUAL(0, rec.events[0].depth);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[1].type);
 	LONGS_EQUAL(0, rec.events[1].depth);
@@ -499,14 +499,14 @@ TEST(StreamArray, ShouldEmitItemsWithCorrectDepth_WhenDefiniteArrayGiven)
 	LONGS_EQUAL(4, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
 	LONGS_EQUAL(0, rec.events[0].depth);
-	LONGS_EQUAL(2, rec.events[0].container_size);
+	LONGLONGS_EQUAL(2ll, rec.events[0].container_size);
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
 	LONGS_EQUAL(1, rec.events[1].depth);
-	LONGS_EQUAL(1, rec.events[1].uint_val);
+	LONGLONGS_EQUAL(1ull, rec.events[1].uint_val);
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
-	LONGS_EQUAL(2, rec.events[2].uint_val);
+	LONGLONGS_EQUAL(2ull, rec.events[2].uint_val);
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
 	LONGS_EQUAL(0, rec.events[3].depth);
@@ -539,7 +539,7 @@ TEST(StreamArray, ShouldEmitIndefiniteArray_WhenIndefArrayGiven)
 
 	LONGS_EQUAL(4, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
-	LONGS_EQUAL(-1, rec.events[0].container_size);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].container_size);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
@@ -603,7 +603,7 @@ TEST(StreamMap, ShouldReportPairCount_WhenDefiniteMapGiven)
 	feed_all(&decoder, msg, sizeof(msg));
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
-	LONGS_EQUAL(2, rec.events[0].container_size);
+	LONGLONGS_EQUAL(2ll, rec.events[0].container_size);
 }
 
 TEST(StreamMap, ShouldEmitMultiplePairs_WhenMultiPairMapGiven)
@@ -627,7 +627,7 @@ TEST(StreamMap, ShouldEmitIndefiniteMap_WhenIndefMapGiven)
 
 	LONGS_EQUAL(4, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
-	LONGS_EQUAL(-1, rec.events[0].container_size);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].container_size);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
 }
 
@@ -660,8 +660,8 @@ TEST(StreamTag, ShouldSetHasTag_WhenTaggedItemGiven)
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
 	CHECK(rec.events[0].has_tag);
-	LONGS_EQUAL(1, rec.events[0].tag);
-	LONGS_EQUAL(0, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(1ull, rec.events[0].tag);
+	LONGLONGS_EQUAL(0ull, rec.events[0].uint_val);
 }
 
 TEST(StreamTag, ShouldSetHasTagOnStart_WhenTaggedArrayGiven)
@@ -673,7 +673,7 @@ TEST(StreamTag, ShouldSetHasTagOnStart_WhenTaggedArrayGiven)
 	LONGS_EQUAL(2, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
 	CHECK(rec.events[0].has_tag);
-	LONGS_EQUAL(0, rec.events[0].tag);
+	LONGLONGS_EQUAL(0ull, rec.events[0].tag);
 
 	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[1].type);
 	CHECK(!rec.events[1].has_tag);
@@ -875,7 +875,7 @@ TEST(StreamReset, ShouldDecodeAfterReset_WhenPreviouslyErrored)
 
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
-	LONGS_EQUAL(5, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(5ull, rec.events[0].uint_val);
 }
 
 TEST(StreamReset, ShouldPreserveCallback_WhenResetCalled)


### PR DESCRIPTION
This pull request introduces a new streaming CBOR decoder to the codebase, allowing incremental, push-based decoding of CBOR data. It includes the implementation, documentation, public API exposure, and test runner setup for the streaming decoder. Additionally, there are minor improvements to the release workflow and error handling.

**Streaming Decoder Implementation and Documentation:**

* Added `cbor/stream.h` header, defining the streaming decoder API, event types, callback mechanism, and decoder state structures. This enables incremental, event-driven decoding of CBOR data.
* Updated `README.md` with a comprehensive section describing the streaming decoder usage, event callbacks, string and container handling, and API summary.

**Public API and Error Handling:**

* Included `cbor/stream.h` in the main `cbor.h` header to expose the streaming decoder API to users.
* Extended `cbor_error_t` enum with `CBOR_NEED_MORE` and `CBOR_ABORTED` error codes to support streaming decoder error reporting.

**Testing:**

* Added a new test runner makefile `tests/runners/stream.mk` for the streaming decoder, specifying source files and test configuration.

**Release Workflow:**

* Updated `.github/workflows/release.yml` to use environment variables and the GitHub CLI for release creation, improving compatibility with recent GitHub Actions changes.