### PR TITLE
fix(encoder): reject non-negative input for negative integer

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -83,7 +83,7 @@ cbor_error_t cbor_encode_negative_integer(cbor_writer_t *writer, int64_t value)
 		return CBOR_INVALID;
 	}
 
-	return encode_core(writer, 1, NULL, ((uint64_t)-value) - 1, false);
+	return encode_core(writer, 1, NULL, (uint64_t)(-1 - value), false);
 }
 
 cbor_error_t cbor_encode_byte_string(cbor_writer_t *writer,

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -79,6 +79,10 @@ cbor_error_t cbor_encode_unsigned_integer(cbor_writer_t *writer, uint64_t value)
 
 cbor_error_t cbor_encode_negative_integer(cbor_writer_t *writer, int64_t value)
 {
+	if (value >= 0) {
+		return CBOR_INVALID;
+	}
+
 	return encode_core(writer, 1, NULL, ((uint64_t)-value) - 1, false);
 }
 

--- a/tests/src/encoder_test.cpp
+++ b/tests/src/encoder_test.cpp
@@ -103,13 +103,35 @@ TEST(Encoder, WhenNegativeIntegerGiven) {
 }
 
 TEST(Encoder, ShouldReturnInvalid_WhenZeroGivenForNegativeInteger) {
+	uint8_t before[sizeof(writer_buffer)];
+
+	memset(writer_buffer, 0xA5, sizeof(writer_buffer));
+	memcpy(before, writer_buffer, sizeof(before));
+
 	LONGS_EQUAL(CBOR_INVALID, cbor_encode_negative_integer(&writer, 0));
 	LONGS_EQUAL(0, writer.bufidx);
+	MEMCMP_EQUAL(before, writer_buffer, sizeof(before));
 }
 
 TEST(Encoder, ShouldReturnInvalid_WhenPositiveGivenForNegativeInteger) {
+	uint8_t before[sizeof(writer_buffer)];
+
+	memset(writer_buffer, 0xA5, sizeof(writer_buffer));
+	memcpy(before, writer_buffer, sizeof(before));
+
 	LONGS_EQUAL(CBOR_INVALID, cbor_encode_negative_integer(&writer, 1));
 	LONGS_EQUAL(0, writer.bufidx);
+	MEMCMP_EQUAL(before, writer_buffer, sizeof(before));
+}
+
+TEST(Encoder, ShouldEncodeInt64Min_WhenNegativeIntegerGiven) {
+	const uint8_t expected[] = {
+		0x3B, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+	};
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_negative_integer(&writer, INT64_MIN));
+	LONGS_EQUAL(sizeof(expected), writer.bufidx);
+	MEMCMP_EQUAL(expected, writer.buf, sizeof(expected));
 }
 
 TEST(Encoder, WhenEncodedLengthByteStringGiven) {

--- a/tests/src/encoder_test.cpp
+++ b/tests/src/encoder_test.cpp
@@ -102,6 +102,16 @@ TEST(Encoder, WhenNegativeIntegerGiven) {
 	MEMCMP_EQUAL(expected, writer.buf, sizeof(expected));
 }
 
+TEST(Encoder, ShouldReturnInvalid_WhenZeroGivenForNegativeInteger) {
+	LONGS_EQUAL(CBOR_INVALID, cbor_encode_negative_integer(&writer, 0));
+	LONGS_EQUAL(0, writer.bufidx);
+}
+
+TEST(Encoder, ShouldReturnInvalid_WhenPositiveGivenForNegativeInteger) {
+	LONGS_EQUAL(CBOR_INVALID, cbor_encode_negative_integer(&writer, 1));
+	LONGS_EQUAL(0, writer.bufidx);
+}
+
 TEST(Encoder, WhenEncodedLengthByteStringGiven) {
 	for (int i = 0; i < 23; i++) {
 		LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_byte_string(&writer,


### PR DESCRIPTION
This pull request improves the robustness of the CBOR encoder by adding input validation to the `cbor_encode_negative_integer` function and introducing new unit tests to verify this behavior. The main focus is to ensure that only negative integers are accepted by the function, and invalid inputs are properly handled.

**Encoder input validation:**

* Added a check in `cbor_encode_negative_integer` (in `encoder.c`) to return `CBOR_INVALID` if the input is zero or positive, preventing invalid encoding attempts.

**Unit tests:**

* Added new tests in `encoder_test.cpp` to verify that `cbor_encode_negative_integer` returns `CBOR_INVALID` and does not modify the buffer when given zero or positive values.