### PR TITLE
feat(tag): add CBOR tag support for encoding and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Stack usage per the major type functions:
 | 3: text string                                     | 32    |
 | 4: array                                           | 32    |
 | 5: map                                             | 32    |
-| 6: tag(not implemented yet)                        | 0     |
+| 6: tag                                             | 32    |
 | 7: floating-point numbers, simple values and break | 32    |
 
 And the call stack for each recursion is 24 bytes.
@@ -124,13 +124,14 @@ size_t item_buffer_bytes = MAX_ITEMS * sizeof(cbor_item_t);
 `sizeof(cbor_item_t)` is platform dependent (e.g. typically 12 bytes on many
 32-bit MCUs, and often 24 bytes on 64-bit hosts).
 
-Each `cbor_item_t` represents one parsed CBOR node (container and leaf both
-count as one item). `cbor_get_item_size()` unit depends on the item type:
+Each `cbor_item_t` represents one parsed CBOR node (container, tag, and leaf
+all count as one item). `cbor_get_item_size()` unit depends on the item type:
 
 * Integer / float / simple value: encoded payload size in bytes
 * Byte/text string (definite-length): string length in bytes
 * Array (definite-length): number of child items
 * Map (definite-length): number of key-value pairs
+* Tag: tag number (e.g. `1` for epoch-based date/time)
 
 For **indefinite-length** strings, arrays, and maps, `cbor_get_item_size()`
 returns the raw CBOR length field, which is the sentinel
@@ -145,6 +146,15 @@ Example (`0xA2 0x61 0x61 0x01 0x61 0x62 0x02`, equivalent to
 * 2 key items (`"a"`, `"b"`)
 * 2 value items (`1`, `2`)
 * total parsed item count (`n`) = 5
+
+When a value is tagged, the tag occupies its own item slot immediately before
+the wrapped item. For `{"a": tag(1, 1234567890)}`:
+
+* 1 map item
+* 1 key item (`"a"`)
+* 1 tag item (tag number = `1`, `cbor_get_item_size()` returns `1`)
+* 1 integer item (`1234567890`)
+* total parsed item count (`n`) = 4
 
 ### Sizing `MAX_ITEMS` (pre-estimation)
 
@@ -227,21 +237,96 @@ cbor_decode(&reader, &items[i], &val, sizeof(val));
 ```c
 cbor_writer_t writer;
 
-cbor_writer_init(&reader, buf, sizeof(buf));
+cbor_writer_init(&writer, buf, sizeof(buf));
 
 cbor_encode_map(&writer, 2);
   /* 1st */
-  cbor_encode_text_string(&writer, "key");
-  cbor_encode_text_string(&writer, "value");
+  cbor_encode_text_string(&writer, "key", 3);
+  cbor_encode_text_string(&writer, "value", 5);
   /* 2nd */
-  cbor_encode_text_string(&writer, "age");
+  cbor_encode_text_string(&writer, "age", 3);
   cbor_encode_negative_integer(&writer, -1);
 ```
+
+#### Tags (RFC 8949 §3.4)
+
+Call `cbor_encode_tag()` immediately before the item it wraps. The caller is
+responsible for ensuring the tag and its wrapped item are written in order — the
+same convention used by `cbor_encode_array()` and `cbor_encode_map()`.
+
+```c
+/* tag(1, 1234567890) — epoch-based date/time */
+cbor_encode_tag(&writer, 1);
+cbor_encode_unsigned_integer(&writer, 1234567890);
+
+/* tag(0, "2006-01-13T20:11:12Z") — date/time string */
+cbor_encode_tag(&writer, 0);
+cbor_encode_text_string(&writer, "2006-01-13T20:11:12Z", 20);
+
+/* Nested tags: tag(1, tag(2, 0)) */
+cbor_encode_tag(&writer, 1);
+cbor_encode_tag(&writer, 2);
+cbor_encode_unsigned_integer(&writer, 0);
+```
+
+#### Decoding tagged values
+
+The parser records each tag as a `CBOR_ITEM_TAG` item. Use
+`cbor_get_tag_number()` to read the tag number; the item immediately following
+it in the `items[]` array is the wrapped value.
+
+```c
+/* tag(1, 1234567890) — epoch-based date/time (RFC 8949 §3.4.2)
+ * Encoded: 0xC1 0x1A 0x49 0x96 0x02 0xD2 */
+uint8_t msg[] = { 0xC1, 0x1A, 0x49, 0x96, 0x02, 0xD2 };
+
+cbor_reader_t reader;
+cbor_item_t items[4];
+size_t n;
+
+cbor_reader_init(&reader, items, sizeof(items) / sizeof(*items));
+cbor_parse(&reader, msg, sizeof(msg), &n);  /* n == 2 */
+
+/* items[0]: CBOR_ITEM_TAG,    cbor_get_tag_number() == 1   */
+/* items[1]: CBOR_ITEM_INTEGER, value == 1234567890          */
+if (items[0].type == CBOR_ITEM_TAG) {
+    cbor_tag_t tag = cbor_get_tag_number(&items[0]);
+
+    uint32_t timestamp = 0;
+    cbor_decode(&reader, &items[1], &timestamp, sizeof(timestamp));
+
+    /* tag == 1, timestamp == 1234567890 */
+}
+```
+
+With `cbor_iterate()`, `CBOR_ITEM_TAG` items are delivered to the callback
+before the wrapped item, so the tag number can be inspected in context:
+
+```c
+static void on_item(const cbor_reader_t *reader,
+        const cbor_item_t *item, const cbor_item_t *parent, void *arg)
+{
+    if (item->type == CBOR_ITEM_TAG) {
+        printf("tag %zu\n", cbor_get_tag_number(item));
+        return;
+    }
+
+    int64_t val = 0;
+    cbor_decode(reader, item, &val, sizeof(val));
+    printf("value %lld\n", (long long)val);
+}
+```
+
+`cbor_unmarshal()` treats tags as transparent: the parser callback registered
+for a map key receives the wrapped value item, not the tag item, regardless of
+how many tags are stacked.
 
 ## Limitation
 
 * The maximum item length is `size_t` because the interface return type is `size_t`. The argument's value in the specification can go up to `uint64_t` though
 * A negative integer ranges down to -2^63-1 other than -2^64 in the specification
 * Sorting of encoded map keys is not supported
-* Tag item is not implemented yet
+* On 32-bit targets where `size_t` is 32 bits, tag numbers above `2^32 - 1`
+  cannot be represented in `cbor_item_t.size`; `cbor_parse()` returns
+  `CBOR_INVALID` for such values
 * `cbor_unmarshal()` only works on the major type 5: map with string key

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -44,7 +44,19 @@ typedef enum {
 	CBOR_ITEM_MAP,
 	CBOR_ITEM_FLOAT,
 	CBOR_ITEM_SIMPLE_VALUE,
+	CBOR_ITEM_TAG, /**< tag number in @p size; wraps the following item */
 } cbor_item_data_t;
+
+/**
+ * Type for a CBOR tag number (RFC 8949 §3.4).
+ *
+ * Currently backed by @c size_t. On 32-bit targets this limits the
+ * representable range to [0, 2^32-1]; tag numbers above that cause
+ * @ref cbor_parse to return @ref CBOR_INVALID.
+ *
+ * Encoding accepts the full @c uint64_t range via @ref cbor_encode_tag.
+ */
+typedef size_t cbor_tag_t;
 
 typedef struct {
 	cbor_item_data_t type;
@@ -113,6 +125,17 @@ uint8_t const *cbor_writer_get_encoded(cbor_writer_t const *writer);
  * @return item data type
  */
 cbor_item_data_t cbor_get_item_type(cbor_item_t const *item);
+
+/**
+ * Get the tag number from a parsed CBOR tag item.
+ *
+ * Behaviour is undefined if @p item is not of type @ref CBOR_ITEM_TAG.
+ *
+ * @param[in] item parsed CBOR item of type @ref CBOR_ITEM_TAG
+ *
+ * @return tag number
+ */
+cbor_tag_t cbor_get_tag_number(cbor_item_t const *item);
 
 /**
  * Get the parsed CBOR size field of an item.

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -145,6 +145,7 @@ cbor_tag_t cbor_get_tag_number(cbor_item_t const *item);
  * - Byte/text string (definite-length): string length in bytes
  * - Array (definite-length): number of child items
  * - Map (definite-length): number of key-value pairs
+ * - Tag: tag number
  *
  * For indefinite-length string/array/map, this returns
  * `(size_t)CBOR_INDEFINITE_VALUE`, which means the size is unknown up front and

--- a/include/cbor/decoder.h
+++ b/include/cbor/decoder.h
@@ -21,6 +21,9 @@ extern "C" {
  * @param[out] buf the buffer where decoded value to be written in
  * @param[in] bufsize the buffer size
  *
+ * @note @ref CBOR_ITEM_TAG is metadata-only. Use @ref cbor_get_tag_number to
+ *       read tag number and decode the wrapped item separately.
+ *
  * @return a code of @ref cbor_error_t
  */
 cbor_error_t cbor_decode(cbor_reader_t const *reader, cbor_item_t const *item,

--- a/include/cbor/encoder.h
+++ b/include/cbor/encoder.h
@@ -33,6 +33,8 @@ cbor_error_t cbor_encode_array_indefinite(cbor_writer_t *writer);
 cbor_error_t cbor_encode_map(cbor_writer_t *writer, size_t length);
 cbor_error_t cbor_encode_map_indefinite(cbor_writer_t *writer);
 
+cbor_error_t cbor_encode_tag(cbor_writer_t *writer, uint64_t tag_number);
+
 cbor_error_t cbor_encode_break(cbor_writer_t *writer);
 
 cbor_error_t cbor_encode_simple(cbor_writer_t *writer, uint8_t value);

--- a/src/common.c
+++ b/src/common.c
@@ -65,6 +65,11 @@ size_t cbor_get_item_size(cbor_item_t const *item)
 	return item->size;
 }
 
+cbor_tag_t cbor_get_tag_number(cbor_item_t const *item)
+{
+	return item->size;
+}
+
 void cbor_reader_init(cbor_reader_t *reader, cbor_item_t *items, size_t maxitems)
 {
 	assert(reader != NULL);

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -156,9 +156,8 @@ cbor_error_t cbor_decode(cbor_reader_t const *reader, cbor_item_t const *item,
 	if (cbor_item_is_break(item)) {
 		return CBOR_BREAK;
 	}
-	/* TAG items carry no decodable payload; tag number is in item->size */
 	if (item->type == CBOR_ITEM_TAG) {
-		return CBOR_SUCCESS;
+		return CBOR_INVALID;
 	}
 	if (item->size > bufsize || bufsize == 0 || buf == NULL) {
 		return CBOR_OVERRUN;

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -33,6 +33,7 @@ static const item_decoder_t decoders[] = {
 	decode_pass,		/* 4: CBOR_ITEM_MAP */
 	decode_float,		/* 5: CBOR_ITEM_FLOAT */
 	decode_simple,		/* 6: CBOR_ITEM_SIMPLE_VALUE */
+	decode_pass,		/* 7: CBOR_ITEM_TAG */
 };
 
 static uint8_t get_simple_value(uint8_t val)
@@ -154,6 +155,10 @@ cbor_error_t cbor_decode(cbor_reader_t const *reader, cbor_item_t const *item,
 {
 	if (cbor_item_is_break(item)) {
 		return CBOR_BREAK;
+	}
+	/* TAG items carry no decodable payload; tag number is in item->size */
+	if (item->type == CBOR_ITEM_TAG) {
+		return CBOR_SUCCESS;
 	}
 	if (item->size > bufsize || bufsize == 0 || buf == NULL) {
 		return CBOR_OVERRUN;

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -149,6 +149,11 @@ cbor_error_t cbor_encode_map_indefinite(cbor_writer_t *writer)
 	return encode_core(writer, 5, NULL, 0, true);
 }
 
+cbor_error_t cbor_encode_tag(cbor_writer_t *writer, uint64_t tag_number)
+{
+	return encode_core(writer, 6, NULL, tag_number, false);
+}
+
 cbor_error_t cbor_encode_break(cbor_writer_t *writer)
 {
 	return encode_core(writer, 7, NULL, 0xff, true);

--- a/src/helper.c
+++ b/src/helper.c
@@ -46,16 +46,35 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 	size_t strkey_len = 0;
 	intptr_t intkey = -1;
 
+	/* TAG items themselves carry no value; the wrapped item is dispatched */
+	if (item->type == CBOR_ITEM_TAG) {
+		return;
+	}
+
 	if (parent && parent->type == CBOR_ITEM_MAP) {
-		if ((item - parent) % 2) { /* key */
+		/* Count non-TAG items from parent+1 to item to get logical
+		 * position, so TAG slots do not disturb key/value detection. */
+		size_t pos = 0;
+		for (const cbor_item_t *p = parent + 1; p <= item; p++) {
+			if (p->type != CBOR_ITEM_TAG) {
+				pos++;
+			}
+		}
+		if (pos % 2 == 1) { /* key position — odd (1-indexed) */
 			return;
 		}
 
-		if ((item - 1)->type == CBOR_ITEM_INTEGER) {
-			cbor_decode(reader, item - 1, &intkey, sizeof(intkey));
+		/* Walk backward past any TAG items to reach the actual key */
+		const cbor_item_t *key = item - 1;
+		while (key > parent && key->type == CBOR_ITEM_TAG) {
+			key--;
+		}
+
+		if (key->type == CBOR_ITEM_INTEGER) {
+			cbor_decode(reader, key, &intkey, sizeof(intkey));
 		} else {
-			strkey = cbor_decode_pointer(reader, item - 1);
-			strkey_len = (item - 1)->size;
+			strkey = cbor_decode_pointer(reader, key);
+			strkey_len = key->size;
 		}
 	}
 
@@ -74,11 +93,16 @@ typedef enum {
 	ITER_RECURSE,                /* container; recurse into children */
 	ITER_RECURSE_CALLBACK_FIRST, /* indefinite string; callback then recurse */
 	ITER_STOP,                   /* MAP size overflow; abort iteration */
+	ITER_TAG,                    /* tag prefix; callback then advance extra */
 } iter_action_t;
 
 static iter_action_t get_iter_action(const cbor_item_t *item,
 		size_t remaining_nodes, size_t *len)
 {
+	if (item->type == CBOR_ITEM_TAG) {
+		return ITER_TAG;
+	}
+
 	if (item->type == CBOR_ITEM_STRING &&
 			item->size == (size_t)CBOR_INDEFINITE_VALUE) {
 		*len = remaining_nodes;
@@ -137,6 +161,15 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			continue;
 		case ITER_STOP:
 			return i + extra;
+		case ITER_TAG:
+			/* TAG is transparent: visible to caller but does not
+			 * consume a logical iteration slot. Advance the physical
+			 * extra counter and re-process the same logical index so
+			 * the wrapped item is seen under the original parent. */
+			(*callback_each)(reader, item, parent, arg);
+			extra++;
+			i--;	/* neutralised by the for-loop's i++ */
+			continue;
 		case ITER_LEAF:
 		default:
 			break;
@@ -222,6 +255,8 @@ const char *cbor_stringify_item(cbor_item_t *item)
 		return "float";
 	case CBOR_ITEM_SIMPLE_VALUE:
 		return "simple value";
+	case CBOR_ITEM_TAG:
+		return "tag";
 	case CBOR_ITEM_UNKNOWN: /* fall through */
 	default:
 		return "unknown";

--- a/src/helper.c
+++ b/src/helper.c
@@ -38,8 +38,15 @@ static const struct cbor_parser *get_parser(const struct parser_ctx *ctx,
 	return NULL;
 }
 
+/* Internal callback type used by iterate_each().
+ * logical_idx is the 0-based position of this item among its logical siblings
+ * (TAG items do not increment the index). */
+typedef void (*iter_cb_t)(const cbor_reader_t *reader,
+		const cbor_item_t *item, const cbor_item_t *parent,
+		size_t logical_idx, void *arg);
+
 static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
-		const cbor_item_t *parent, void *arg)
+		const cbor_item_t *parent, size_t logical_idx, void *arg)
 {
 	struct parser_ctx *ctx = (struct parser_ctx *)arg;
 	const void *strkey = NULL;
@@ -52,15 +59,8 @@ static void parse_item(const cbor_reader_t *reader, const cbor_item_t *item,
 	}
 
 	if (parent && parent->type == CBOR_ITEM_MAP) {
-		/* Count non-TAG items from parent+1 to item to get logical
-		 * position, so TAG slots do not disturb key/value detection. */
-		size_t pos = 0;
-		for (const cbor_item_t *p = parent + 1; p <= item; p++) {
-			if (p->type != CBOR_ITEM_TAG) {
-				pos++;
-			}
-		}
-		if (pos % 2 == 1) { /* key position — odd (1-indexed) */
+		/* logical_idx is 0-based: even = key, odd = value */
+		if (logical_idx % 2 == 0) {
 			return;
 		}
 
@@ -134,9 +134,7 @@ static iter_action_t get_iter_action(const cbor_item_t *item,
 static size_t iterate_each(const cbor_reader_t *reader,
 		const cbor_item_t *items, size_t nr_items, size_t max_nodes,
 		const cbor_item_t *parent,
-		void (*callback_each)(const cbor_reader_t *reader,
-				const cbor_item_t *item,
-				const cbor_item_t *parent, void *arg),
+		iter_cb_t callback_each,
 		void *arg)
 {
 	size_t extra = 0;
@@ -152,7 +150,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 
 		switch (get_iter_action(item, remaining_nodes, &len)) {
 		case ITER_RECURSE_CALLBACK_FIRST:
-			(*callback_each)(reader, item, parent, arg);
+			(*callback_each)(reader, item, parent, i, arg);
 			/* fall through */
 		case ITER_RECURSE:
 			extra += iterate_each(reader, item + 1, len,
@@ -166,7 +164,7 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			 * consume a logical iteration slot. Advance the physical
 			 * extra counter and re-process the same logical index so
 			 * the wrapped item is seen under the original parent. */
-			(*callback_each)(reader, item, parent, arg);
+			(*callback_each)(reader, item, parent, i, arg);
 			extra++;
 			i--;	/* neutralised by the for-loop's i++ */
 			continue;
@@ -184,10 +182,27 @@ static size_t iterate_each(const cbor_reader_t *reader,
 			break;
 		}
 
-		(*callback_each)(reader, item, parent, arg);
+		(*callback_each)(reader, item, parent, i, arg);
 	}
 
 	return i + extra;
+}
+
+/* Trampoline: adapts the public cbor_iterate() callback (no logical_idx) to
+ * the internal iter_cb_t signature so callers are not affected. */
+struct iterate_wrap {
+	void (*cb)(const cbor_reader_t *, const cbor_item_t *,
+		   const cbor_item_t *, void *);
+	void *arg;
+};
+
+static void iterate_trampoline(const cbor_reader_t *reader,
+		const cbor_item_t *item, const cbor_item_t *parent,
+		size_t logical_idx, void *arg)
+{
+	(void)logical_idx;
+	const struct iterate_wrap *w = (const struct iterate_wrap *)arg;
+	w->cb(reader, item, parent, w->arg);
 }
 
 bool cbor_unmarshal(cbor_reader_t *reader, const struct cbor_parser *parsers,
@@ -217,8 +232,9 @@ size_t cbor_iterate(const cbor_reader_t *reader, const cbor_item_t *parent,
 				const cbor_item_t *parent, void *arg),
 		void *arg)
 {
+	struct iterate_wrap wrap = { callback_each, arg };
 	return iterate_each(reader, reader->items, reader->itemidx,
-			reader->itemidx, parent, callback_each, arg);
+			reader->itemidx, parent, iterate_trampoline, &wrap);
 }
 
 const char *cbor_stringify_error(cbor_error_t err)

--- a/src/parser.c
+++ b/src/parser.c
@@ -257,11 +257,39 @@ static cbor_error_t do_recursive(struct parser_context *ctx)
 	return CBOR_SUCCESS;
 }
 
-/* TODO: Implement tag */
 static cbor_error_t do_tag(struct parser_context *ctx)
 {
-	(void)ctx;
-	return CBOR_INVALID;
+	if (ctx->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
+		return CBOR_ILLEGAL;
+	}
+
+	size_t tag_offset = ctx->reader->msgidx;
+
+	/* Read tag number as uint64_t to detect overflow on 32-bit targets */
+	uint64_t tag_number = 0;
+	if (ctx->following_bytes == 0) {
+		tag_number = ctx->additional_info;
+	} else {
+		const uint8_t *msg = &ctx->reader->msg[ctx->reader->msgidx];
+		cbor_copy((uint8_t *)&tag_number, &msg[1], ctx->following_bytes);
+	}
+	ctx->reader->msgidx += (size_t)ctx->following_bytes + 1;
+
+	if (tag_number > (uint64_t)SIZE_MAX) {
+		return CBOR_INVALID;
+	}
+
+	set_item(ctx, CBOR_ITEM_TAG, tag_offset, (cbor_tag_t)tag_number);
+	ctx->reader->itemidx++;
+
+	size_t nparsed = 0;
+	cbor_error_t err = parse(ctx, 1, &nparsed);
+
+	if (nparsed == 0) {
+		return is_item_buffer_overrun(ctx)? CBOR_OVERRUN : CBOR_ILLEGAL;
+	}
+
+	return err;
 }
 
 static cbor_error_t do_float_and_other(struct parser_context *ctx)

--- a/tests/runners/tag.mk
+++ b/tests/runners/tag.mk
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = tag
+
+SRC_FILES = \
+	../src/common.c \
+	../src/encoder.c \
+	../src/ieee754.c \
+	../src/parser.c \
+	../src/decoder.c \
+	../src/helper.c \
+
+TEST_SRC_FILES = \
+	src/tag_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS =
+
+include MakefileRunner.mk

--- a/tests/src/tag_test.cpp
+++ b/tests/src/tag_test.cpp
@@ -306,9 +306,9 @@ TEST(TagEncoder, ShouldEncodeNestedTags)
 
 TEST(TagEncoder, ShouldReturnOverrun_WhenBufferTooSmall)
 {
-	uint8_t tiny[0];
+	uint8_t tiny[1];
 	cbor_writer_t w;
-	cbor_writer_init(&w, tiny, sizeof(tiny));
+	cbor_writer_init(&w, tiny, 0u);
 
 	LONGS_EQUAL(CBOR_OVERRUN, cbor_encode_tag(&w, 1));
 }

--- a/tests/src/tag_test.cpp
+++ b/tests/src/tag_test.cpp
@@ -1,0 +1,458 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestHarness_c.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include <cstdint>
+#include <cstring>
+#include "cbor/cbor.h"
+
+/* ------------------------------------------------------------------ */
+/* Helpers shared by all groups                                         */
+/* ------------------------------------------------------------------ */
+
+static void count_item(const cbor_reader_t *, const cbor_item_t *,
+		const cbor_item_t *, void *arg)
+{
+	(*static_cast<size_t *>(arg))++;
+}
+
+/* ------------------------------------------------------------------ */
+/* Parser group                                                         */
+/* ------------------------------------------------------------------ */
+
+TEST_GROUP(TagParser)
+{
+	cbor_reader_t reader;
+	cbor_item_t items[32];
+	size_t n;
+
+	void setup(void)
+	{
+		cbor_reader_init(&reader, items,
+				sizeof(items) / sizeof(items[0]));
+		n = 0;
+	}
+	void teardown(void) {}
+};
+
+TEST(TagParser, ShouldParseTag_WhenSimpleTagGiven)
+{
+	/* tag(1, 0)  →  0xC1 0x00 */
+	uint8_t msg[] = { 0xC1, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[0].type);
+	LONGS_EQUAL(1,                 items[0].size);  /* tag number */
+	LONGS_EQUAL(0,                 items[0].offset);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[1].type);
+}
+
+TEST(TagParser, ShouldParseNestedTags_WhenTagWrapsAnotherTag)
+{
+	/* tag(1, tag(2, 0))  →  0xC1 0xC2 0x00 */
+	uint8_t msg[] = { 0xC1, 0xC2, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(3, n);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[0].type);
+	LONGS_EQUAL(1,                 items[0].size);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[1].type);
+	LONGS_EQUAL(2,                 items[1].size);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[2].type);
+}
+
+TEST(TagParser, ShouldParseTagInsideArray)
+{
+	/* [tag(1, 0)]  →  0x81 0xC1 0x00 */
+	uint8_t msg[] = { 0x81, 0xC1, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(3, n);
+	LONGS_EQUAL(CBOR_ITEM_ARRAY,   items[0].type);
+	LONGS_EQUAL(1,                 items[0].size);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[1].type);
+	LONGS_EQUAL(1,                 items[1].size);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[2].type);
+}
+
+TEST(TagParser, ShouldParseTagInMapValue)
+{
+	/* {"k": tag(1, 42)}  →  0xA1 0x61 0x6B 0xC1 0x18 0x2A */
+	uint8_t msg[] = { 0xA1, 0x61, 0x6B, 0xC1, 0x18, 0x2A };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+	LONGS_EQUAL(CBOR_ITEM_MAP,     items[0].type);
+	LONGS_EQUAL(CBOR_ITEM_STRING,  items[1].type);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[2].type);
+	LONGS_EQUAL(1,                 items[2].size);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[3].type);
+}
+
+TEST(TagParser, ShouldParseTagWrappingArray)
+{
+	/* tag(1, [1, 2])  →  0xC1 0x82 0x01 0x02 */
+	uint8_t msg[] = { 0xC1, 0x82, 0x01, 0x02 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(4, n);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[0].type);
+	LONGS_EQUAL(CBOR_ITEM_ARRAY,   items[1].type);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[2].type);
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[3].type);
+}
+
+TEST(TagParser, ShouldParseMultiByteTagNumber)
+{
+	/* tag(0x1000, 0)  →  0xD9 0x10 0x00 0x00 */
+	uint8_t msg[] = { 0xD9, 0x10, 0x00, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+	LONGS_EQUAL(CBOR_ITEM_TAG, items[0].type);
+	LONGS_EQUAL(0x1000,        items[0].size);
+}
+
+TEST(TagParser, ShouldReturnIllegal_WhenTagHasNoFollowingItem)
+{
+	/* tag(1) with nothing after it */
+	uint8_t msg[] = { 0xC1 };
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+}
+
+TEST(TagParser, ShouldReturnIllegal_WhenIndefiniteTagGiven)
+{
+	/* 0xDF = major 6, additional_info 31 — indefinite tag (invalid) */
+	uint8_t msg[] = { 0xDF };
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_parse(&reader, msg, sizeof(msg), &n));
+}
+
+TEST(TagParser, ShouldReturnOverrun_WhenItemBufferTooSmallForTag)
+{
+	/* tag(1, 0): needs 2 item slots; give only 1 */
+	cbor_item_t tiny[1];
+	cbor_reader_t r;
+	cbor_reader_init(&r, tiny, 1);
+
+	uint8_t msg[] = { 0xC1, 0x00 };
+	size_t parsed = 0;
+
+	LONGS_EQUAL(CBOR_OVERRUN, cbor_parse(&r, msg, sizeof(msg), &parsed));
+}
+
+TEST(TagParser, ShouldCountTagItems_WhenCountingItems)
+{
+	/* tag(1, 0) — both TAG and INT must be counted */
+	uint8_t msg[] = { 0xC1, 0x00 };
+	size_t counted = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &counted));
+	LONGS_EQUAL(2, counted);
+}
+
+TEST(TagParser, ShouldCountNestedTagItems)
+{
+	/* tag(1, tag(2, 0)) = 3 items */
+	uint8_t msg[] = { 0xC1, 0xC2, 0x00 };
+	size_t counted = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_count_items(msg, sizeof(msg), &counted));
+	LONGS_EQUAL(3, counted);
+}
+
+TEST(TagParser, ShouldStringifyTag)
+{
+	cbor_item_t tag = { CBOR_ITEM_TAG, 0, 1 };
+	STRCMP_EQUAL("tag", cbor_stringify_item(&tag));
+}
+
+TEST(TagParser, ShouldReturnTagNumber_WhenGetTagNumberCalled)
+{
+	/* tag(1, 0) */
+	uint8_t msg[] = { 0xC1, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(CBOR_ITEM_TAG, items[0].type);
+	LONGS_EQUAL(1, cbor_get_tag_number(&items[0]));
+}
+
+TEST(TagParser, ShouldDecodeWrappedValue_WhenTaggedIntegerGiven)
+{
+	/* tag(1, 1234567890)  →  0xC1 0x1A 0x49 0x96 0x02 0xD2 */
+	uint8_t msg[] = { 0xC1, 0x1A, 0x49, 0x96, 0x02, 0xD2 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+	LONGS_EQUAL(CBOR_ITEM_TAG,     items[0].type);
+	LONGS_EQUAL(1,                 cbor_get_tag_number(&items[0]));
+	LONGS_EQUAL(CBOR_ITEM_INTEGER, items[1].type);
+
+	uint32_t timestamp = 0;
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[1], &timestamp, sizeof(timestamp)));
+	LONGS_EQUAL(1234567890, timestamp);
+}
+
+TEST(TagParser, ShouldDecodeWrappedString_WhenTaggedTextStringGiven)
+{
+	/* tag(0, "t")  →  0xC0 0x61 0x74 */
+	uint8_t msg[] = { 0xC0, 0x61, 0x74 };
+	char buf[8] = {};
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(2, n);
+	LONGS_EQUAL(0, cbor_get_tag_number(&items[0]));
+	LONGS_EQUAL(CBOR_ITEM_STRING, items[1].type);
+
+	LONGS_EQUAL(CBOR_SUCCESS,
+		    cbor_decode(&reader, &items[1], buf, sizeof(buf)));
+	LONGS_EQUAL('t', buf[0]);
+}
+
+/* ------------------------------------------------------------------ */
+/* Encoder group                                                        */
+/* ------------------------------------------------------------------ */
+
+TEST_GROUP(TagEncoder)
+{
+	cbor_writer_t writer;
+	uint8_t buf[64];
+
+	void setup(void)
+	{
+		cbor_writer_init(&writer, buf, sizeof(buf));
+	}
+	void teardown(void) {}
+};
+
+TEST(TagEncoder, ShouldEncodeTag_WhenSmallTagNumberGiven)
+{
+	/* tag(1) → 0xC1 */
+	const uint8_t expected[] = { 0xC1 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 1));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldEncodeTagWithUnsignedInteger)
+{
+	/* tag(1, 0) → 0xC1 0x00 */
+	const uint8_t expected[] = { 0xC1, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 1));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_unsigned_integer(&writer, 0));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldEncodeTagWithTextString)
+{
+	/* tag(0, "t") → 0xC0 0x61 0x74 */
+	const uint8_t expected[] = { 0xC0, 0x61, 0x74 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 0));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_text_string(&writer, "t", 1));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldEncodeTwoByteTagNumber)
+{
+	/* tag(0x1000) → 0xD9 0x10 0x00 */
+	const uint8_t expected[] = { 0xD9, 0x10, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 0x1000));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldEncodeFourByteTagNumber)
+{
+	/* tag(0x10000) → 0xDA 0x00 0x01 0x00 0x00 */
+	const uint8_t expected[] = { 0xDA, 0x00, 0x01, 0x00, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 0x10000));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldEncodeNestedTags)
+{
+	/* tag(1, tag(2, 0)) → 0xC1 0xC2 0x00 */
+	const uint8_t expected[] = { 0xC1, 0xC2, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 1));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_tag(&writer, 2));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_encode_unsigned_integer(&writer, 0));
+	LONGS_EQUAL(sizeof(expected), cbor_writer_len(&writer));
+	MEMCMP_EQUAL(expected, cbor_writer_get_encoded(&writer),
+			sizeof(expected));
+}
+
+TEST(TagEncoder, ShouldReturnOverrun_WhenBufferTooSmall)
+{
+	uint8_t tiny[0];
+	cbor_writer_t w;
+	cbor_writer_init(&w, tiny, sizeof(tiny));
+
+	LONGS_EQUAL(CBOR_OVERRUN, cbor_encode_tag(&w, 1));
+}
+
+/* ------------------------------------------------------------------ */
+/* Iterate group                                                        */
+/* ------------------------------------------------------------------ */
+
+TEST_GROUP(TagIterate)
+{
+	cbor_reader_t reader;
+	cbor_item_t items[32];
+
+	void setup(void)
+	{
+		cbor_reader_init(&reader, items,
+				sizeof(items) / sizeof(items[0]));
+	}
+	void teardown(void) {}
+};
+
+TEST(TagIterate, ShouldVisitTagAndWrappedItem)
+{
+	/* tag(1, 0) → callback for TAG + callback for INT */
+	uint8_t msg[] = { 0xC1, 0x00 };
+	size_t n = 0;
+	size_t count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	cbor_iterate(&reader, nullptr, count_item, &count);
+	LONGS_EQUAL(2, count);
+}
+
+TEST(TagIterate, ShouldVisitBothNestedTags)
+{
+	/* tag(1, tag(2, 0)) → 3 callbacks */
+	uint8_t msg[] = { 0xC1, 0xC2, 0x00 };
+	size_t n = 0;
+	size_t count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	cbor_iterate(&reader, nullptr, count_item, &count);
+	LONGS_EQUAL(3, count);
+}
+
+TEST(TagIterate, ShouldVisitTagInsideArray)
+{
+	/* [tag(1, 0)] → TAG + INT visible; ARRAY container not leaf-counted */
+	uint8_t msg[] = { 0x81, 0xC1, 0x00 };
+	size_t n = 0;
+	size_t count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(3, cbor_iterate(&reader, nullptr, count_item, &count));
+	LONGS_EQUAL(2, count);  /* TAG + INT; ARRAY is a container, no leaf callback */
+}
+
+TEST(TagIterate, ShouldHandleTagFollowedBySibling)
+{
+	/* tag(1, 0), 99 — sibling after tagged item */
+	uint8_t msg[] = { 0xC1, 0x00, 0x18, 0x63 };
+	size_t n = 0;
+	size_t count = 0;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	cbor_iterate(&reader, nullptr, count_item, &count);
+	LONGS_EQUAL(3, count);  /* TAG + INT(0) + INT(99) */
+}
+
+/* ------------------------------------------------------------------ */
+/* Unmarshal group                                                      */
+/* ------------------------------------------------------------------ */
+
+static void on_value(const cbor_reader_t *reader,
+		const struct cbor_parser *parser,
+		const cbor_item_t *item, void *arg)
+{
+	(void)reader;
+	(void)parser;
+	mock().actualCall("on_value")
+		.withParameter("type", (int)item->type);
+	if (arg) {
+		int64_t *out = static_cast<int64_t *>(arg);
+		cbor_decode(reader, item, out, sizeof(*out));
+	}
+}
+
+static const struct cbor_parser kv_parsers[] = {
+	{ .key = "k", .keylen = 1, .run = on_value },
+};
+
+TEST_GROUP(TagUnmarshal)
+{
+	cbor_reader_t reader;
+	cbor_item_t items[32];
+
+	void setup(void)
+	{
+		cbor_reader_init(&reader, items,
+				sizeof(items) / sizeof(items[0]));
+	}
+	void teardown(void)
+	{
+		mock().checkExpectations();
+		mock().clear();
+	}
+};
+
+TEST(TagUnmarshal, ShouldDispatchWrappedItem_WhenMapValueIsTagged)
+{
+	/* {"k": tag(1, 42)}  →  0xA1 0x61 0x6B 0xC1 0x18 0x2A */
+	uint8_t msg[] = { 0xA1, 0x61, 0x6B, 0xC1, 0x18, 0x2A };
+	int64_t got = 0;
+
+	mock().expectOneCall("on_value")
+		.withParameter("type", (int)CBOR_ITEM_INTEGER);
+
+	LONGS_EQUAL(true, cbor_unmarshal(&reader,
+			kv_parsers, sizeof(kv_parsers) / sizeof(*kv_parsers),
+			msg, sizeof(msg), &got));
+	LONGS_EQUAL(42, got);
+}
+
+TEST(TagUnmarshal, ShouldDispatchWrappedItem_WhenValueHasNestedTags)
+{
+	/* {"k": tag(1, tag(2, 7))}  →  0xA1 0x61 0x6B 0xC1 0xC2 0x07 */
+	uint8_t msg[] = { 0xA1, 0x61, 0x6B, 0xC1, 0xC2, 0x07 };
+	int64_t got = 0;
+
+	mock().expectOneCall("on_value")
+		.withParameter("type", (int)CBOR_ITEM_INTEGER);
+
+	LONGS_EQUAL(true, cbor_unmarshal(&reader,
+			kv_parsers, sizeof(kv_parsers) / sizeof(*kv_parsers),
+			msg, sizeof(msg), &got));
+	LONGS_EQUAL(7, got);
+}
+
+TEST(TagUnmarshal, ShouldNotDispatch_WhenOnlyTagWithNoValueInMap)
+{
+	/* Malformed: {"k": tag(1)} — tag with no following item: parse fails */
+	uint8_t msg[] = { 0xA1, 0x61, 0x6B, 0xC1 };
+
+	LONGS_EQUAL(false, cbor_unmarshal(&reader,
+			kv_parsers, sizeof(kv_parsers) / sizeof(*kv_parsers),
+			msg, sizeof(msg), nullptr));
+}

--- a/tests/src/tag_test.cpp
+++ b/tests/src/tag_test.cpp
@@ -185,6 +185,27 @@ TEST(TagParser, ShouldReturnTagNumber_WhenGetTagNumberCalled)
 	LONGS_EQUAL(1, cbor_get_tag_number(&items[0]));
 }
 
+TEST(TagParser, ShouldReturnTagNumber_WhenGetItemSizeCalledForTag)
+{
+	uint8_t msg[] = { 0xC1, 0x00 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(CBOR_ITEM_TAG, items[0].type);
+	LONGS_EQUAL(1, cbor_get_item_size(&items[0]));
+}
+
+TEST(TagParser, ShouldReturnInvalid_WhenDecodingTagItem)
+{
+	uint8_t msg[] = { 0xC1, 0x00 };
+	uint32_t out = 0x12345678;
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_parse(&reader, msg, sizeof(msg), &n));
+	LONGS_EQUAL(CBOR_ITEM_TAG, items[0].type);
+	LONGS_EQUAL(CBOR_INVALID,
+		    cbor_decode(&reader, &items[0], &out, sizeof(out)));
+	LONGS_EQUAL(0x12345678, out);
+}
+
 TEST(TagParser, ShouldDecodeWrappedValue_WhenTaggedIntegerGiven)
 {
 	/* tag(1, 1234567890)  →  0xC1 0x1A 0x49 0x96 0x02 0xD2 */


### PR DESCRIPTION
This pull request adds full support for CBOR tags (major type 6) to the codebase, including encoding, decoding, iteration, and documentation. Tags are now parsed as their own item type, can be encoded with a new API, and are handled transparently in iteration and unmarshalling. The documentation and tests are updated to reflect and exercise these capabilities.

**CBOR Tag Support**

* Added `CBOR_ITEM_TAG` type to `cbor_item_data_t`, and defined `cbor_tag_t` as the tag number type, with appropriate range and overflow handling for 32-bit and 64-bit targets (`include/cbor/base.h`, `src/common.c`, `src/parser.c`). [[1]](diffhunk://#diff-a6d74314c8a71726789893ea2f15bcf36c0e4c38e8aea474b0fa01ba786dd984R47-R60) [[2]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fR68-R72) [[3]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL260-R294)
* Implemented `cbor_encode_tag()` for encoding tags, and updated the encoder to support major type 6 (`include/cbor/encoder.h`, `src/encoder.c`). [[1]](diffhunk://#diff-d864d7f214d2a97fb950c42e6240f1805dee2fbd21c7bfbf7f43b29f5181aeb4R36-R37) [[2]](diffhunk://#diff-4606434a65bd04502916f71a2adf2774435ab6aab3a2f2a7a7b04d378d52e326R152-R156)
* Updated the parser and decoder to recognize, parse, and skip over tag items, and to store the tag number in the item structure (`src/parser.c`, `src/decoder.c`). [[1]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL260-R294) [[2]](diffhunk://#diff-4cbe7df18de64ed82fb5194fac01670885070bba75eaaaae00ed485b9a50bfdbR36) [[3]](diffhunk://#diff-4cbe7df18de64ed82fb5194fac01670885070bba75eaaaae00ed485b9a50bfdbR159-R162)
* Modified iteration and helper logic so that tags are visible to callbacks but do not interfere with logical item positions (e.g., map keys/values), and added stringification support (`src/helper.c`). [[1]](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeR49-R77) [[2]](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeR96-R105) [[3]](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeR164-R172) [[4]](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeR258-R259)

**Documentation and Examples**

* Updated `README.md` to document tag support, including stack usage, item counting, encoding/decoding APIs, and example code for both encoding and parsing tagged values. Also clarified limitations and behavior on 32-bit targets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R97) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R134) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R150-R158) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L230-R331)

**Testing**

* Added a new test runner for tag functionality in `tests/runners/tag.mk`.