### PR TITLE
feat(stream): add streaming CBOR decoder API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,21 +21,10 @@ jobs:
         run: make -C tests install
       - name: Unit Test
         run: make -C tests
-      - name: Get Version
-        id: get_version
-        run: echo "::set-output name=VERSION::$(cat build/version.txt)"
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
-          body: |
-            ${{ steps.get_version.outputs.VERSION }}
-
-            ## Features
-            ## Bug Fixes
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -213,10 +213,11 @@ static bool on_event(const cbor_stream_event_t *event,
     case CBOR_STREAM_EVENT_TEXT:
         printf("text[%zu/%lld]: %.*s\n",
                data->str.len, (long long)data->str.total,
-               (int)data->str.len, (const char *)data->str.ptr);
+               (int)data->str.len,
+               data->str.ptr ? (const char *)data->str.ptr : "");
         break;
     case CBOR_STREAM_EVENT_BYTES:
-        /* data->str.ptr points directly into the caller's buffer */
+        /* data->str.ptr points into the caller's buffer, or is NULL when len == 0 */
         break;
     case CBOR_STREAM_EVENT_ARRAY_START:
         printf("array(%lld) depth=%u\n",
@@ -286,7 +287,7 @@ if (cbor_stream_feed(&decoder, bad_data, len) != CBOR_SUCCESS) {
 | --- | --- | --- |
 | `CBOR_STREAM_EVENT_UINT` | `data->uint` | unsigned integer |
 | `CBOR_STREAM_EVENT_INT` | `data->sint` | negative integer |
-| `CBOR_STREAM_EVENT_BYTES` / `_TEXT` | `data->str` | `ptr` into caller's buffer; chunked for long/indefinite strings |
+| `CBOR_STREAM_EVENT_BYTES` / `_TEXT` | `data->str` | `ptr` into caller's buffer, or `NULL` when `len == 0`; indefinite strings end with a final zero-length BREAK chunk carrying `last=true` |
 | `CBOR_STREAM_EVENT_ARRAY_START` / `_END` | `data->container.size` (`-1` if indefinite) / NULL | container open/close |
 | `CBOR_STREAM_EVENT_MAP_START` / `_END` | `data->container.size` (`-1` if indefinite) / NULL | `event->is_map_key` tracks key/value position |
 | `CBOR_STREAM_EVENT_TAG` | `data->tag` | emitted before the wrapped item's event(s) |
@@ -303,7 +304,7 @@ if (cbor_stream_feed(&decoder, bad_data, len) != CBOR_SUCCESS) {
 | `CBOR_NEED_MORE` | `finish()` called with an incomplete item or open container |
 | `CBOR_ILLEGAL` | reserved additional-info byte; malformed encoding |
 | `CBOR_INVALID` | well-formed but semantically invalid (e.g. negative integer overflows `int64`) |
-| `CBOR_EXCESSIVE` | nesting deeper than `CBOR_RECURSION_MAX_LEVEL` |
+| `CBOR_EXCESSIVE` | nesting deeper than `CBOR_RECURSION_MAX_LEVEL` or tag nesting beyond `CBOR_STREAM_MAX_PENDING_TAGS` |
 | `CBOR_ABORTED` | callback returned `false` |
 
 After any non-`CBOR_SUCCESS` return the decoder is in a sticky error state.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ if (cbor_stream_feed(&decoder, bad_data, len) != CBOR_SUCCESS) {
 | `CBOR_STREAM_EVENT_TAG` | `data->tag` | emitted before the wrapped item's event(s) |
 | `CBOR_STREAM_EVENT_FLOAT` | `data->flt` | half/single/double all promoted to `double` |
 | `CBOR_STREAM_EVENT_BOOL` | `data->boolean` | |
-| `CBOR_STREAM_EVENT_NULL` / `_UNDEFINED` | NULL | |
+| `CBOR_STREAM_EVENT_NULL` / `_UNDEFINED` | (unused) | callback receives a non-NULL `data` pointer, but no payload field is used |
 | `CBOR_STREAM_EVENT_SIMPLE` | `data->simple` | unassigned simple value |
 
 #### Error codes
@@ -307,9 +307,14 @@ if (cbor_stream_feed(&decoder, bad_data, len) != CBOR_SUCCESS) {
 | `CBOR_EXCESSIVE` | nesting deeper than `CBOR_RECURSION_MAX_LEVEL` or tag nesting beyond `CBOR_STREAM_MAX_PENDING_TAGS` |
 | `CBOR_ABORTED` | callback returned `false` |
 
-After any non-`CBOR_SUCCESS` return the decoder is in a sticky error state.
-Subsequent `feed()` / `finish()` calls return the same error immediately.
-Call `cbor_stream_reset()` to recover.
+After any non-`CBOR_SUCCESS` return produced while operating on a valid decoder
+instance, the decoder is in a sticky error state. Subsequent `feed()` /
+`finish()` calls return the same error immediately until you call
+`cbor_stream_reset()`.
+
+API-level argument validation failures (for example `NULL` decoder/callback, or
+`NULL` data with non-zero length) may also return `CBOR_INVALID`, but they do
+not modify decoder state and therefore are not sticky.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,126 @@ if (err == CBOR_OVERRUN) {
 In this case, `n` contains only the number of items actually stored before the
 overrun.
 
+### Streaming Decoder
+
+The streaming decoder processes CBOR byte-by-byte (or in any chunk size) without
+requiring the full message up front.  It issues events via a callback as each
+item is decoded, so it works on constrained systems where the complete payload
+may not fit in RAM at once.
+
+```c
+#include "cbor/stream.h"
+
+static bool on_event(const cbor_stream_event_t *event,
+        const cbor_stream_data_t *data, void *arg)
+{
+    switch (event->type) {
+    case CBOR_STREAM_EVENT_UINT:
+        printf("uint: %llu\n", (unsigned long long)data->uint);
+        break;
+    case CBOR_STREAM_EVENT_INT:
+        printf("int: %lld\n", (long long)data->sint);
+        break;
+    case CBOR_STREAM_EVENT_TEXT:
+        printf("text[%zu/%lld]: %.*s\n",
+               data->str.len, (long long)data->str.total,
+               (int)data->str.len, (const char *)data->str.ptr);
+        break;
+    case CBOR_STREAM_EVENT_BYTES:
+        /* data->str.ptr points directly into the caller's buffer */
+        break;
+    case CBOR_STREAM_EVENT_ARRAY_START:
+        printf("array(%lld) depth=%u\n",
+               (long long)data->container.size, event->depth);
+        break;
+    case CBOR_STREAM_EVENT_ARRAY_END:
+        break;
+    case CBOR_STREAM_EVENT_MAP_START:
+        printf("map(%lld) depth=%u key=%d\n",
+               (long long)data->container.size,
+               event->depth, event->is_map_key);
+        break;
+    case CBOR_STREAM_EVENT_MAP_END:
+        break;
+    case CBOR_STREAM_EVENT_TAG:
+        printf("tag(%llu)\n", (unsigned long long)data->tag);
+        break;
+    case CBOR_STREAM_EVENT_FLOAT:
+        printf("float: %g\n", data->flt);
+        break;
+    case CBOR_STREAM_EVENT_BOOL:
+        printf("bool: %s\n", data->boolean ? "true" : "false");
+        break;
+    case CBOR_STREAM_EVENT_NULL:
+        printf("null\n");
+        break;
+    default:
+        break;
+    }
+    return true; /* return false to abort decoding */
+}
+
+cbor_stream_decoder_t decoder;
+cbor_stream_init(&decoder, on_event, NULL);
+
+/* Feed any number of chunks — partial items are held in decoder state */
+cbor_error_t err = cbor_stream_feed(&decoder, chunk, chunk_len);
+if (err != CBOR_SUCCESS) {
+    /* handle error */
+}
+
+/* After the last chunk, verify the stream ended on a clean boundary */
+err = cbor_stream_finish(&decoder);
+```
+
+Feeding can be split across as many calls as needed:
+
+```c
+/* byte-at-a-time — fully supported */
+for (size_t i = 0; i < msg_len; i++) {
+    cbor_stream_feed(&decoder, &msg[i], 1);
+}
+cbor_stream_finish(&decoder);
+```
+
+To reuse the decoder after an error, call `cbor_stream_reset()`:
+
+```c
+if (cbor_stream_feed(&decoder, bad_data, len) != CBOR_SUCCESS) {
+    cbor_stream_reset(&decoder); /* clears error, preserves callback */
+}
+```
+
+#### Events
+
+| Event | `data` field | Notes |
+| --- | --- | --- |
+| `CBOR_STREAM_EVENT_UINT` | `data->uint` | unsigned integer |
+| `CBOR_STREAM_EVENT_INT` | `data->sint` | negative integer |
+| `CBOR_STREAM_EVENT_BYTES` / `_TEXT` | `data->str` | `ptr` into caller's buffer; chunked for long/indefinite strings |
+| `CBOR_STREAM_EVENT_ARRAY_START` / `_END` | `data->container.size` (`-1` if indefinite) / NULL | container open/close |
+| `CBOR_STREAM_EVENT_MAP_START` / `_END` | `data->container.size` (`-1` if indefinite) / NULL | `event->is_map_key` tracks key/value position |
+| `CBOR_STREAM_EVENT_TAG` | `data->tag` | emitted before the wrapped item's event(s) |
+| `CBOR_STREAM_EVENT_FLOAT` | `data->flt` | half/single/double all promoted to `double` |
+| `CBOR_STREAM_EVENT_BOOL` | `data->boolean` | |
+| `CBOR_STREAM_EVENT_NULL` / `_UNDEFINED` | NULL | |
+| `CBOR_STREAM_EVENT_SIMPLE` | `data->simple` | unassigned simple value |
+
+#### Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `CBOR_SUCCESS` | all bytes consumed cleanly |
+| `CBOR_NEED_MORE` | `finish()` called with an incomplete item or open container |
+| `CBOR_ILLEGAL` | reserved additional-info byte; malformed encoding |
+| `CBOR_INVALID` | well-formed but semantically invalid (e.g. negative integer overflows `int64`) |
+| `CBOR_EXCESSIVE` | nesting deeper than `CBOR_RECURSION_MAX_LEVEL` |
+| `CBOR_ABORTED` | callback returned `false` |
+
+After any non-`CBOR_SUCCESS` return the decoder is in a sticky error state.
+Subsequent `feed()` / `finish()` calls return the same error immediately.
+Call `cbor_stream_reset()` to recover.
+
 ## Tools
 
 ### Item counter script

--- a/cbor.cmake
+++ b/cbor.cmake
@@ -7,5 +7,6 @@ list(APPEND CBOR_SRCS
 	${CMAKE_CURRENT_LIST_DIR}/src/encoder.c
 	${CMAKE_CURRENT_LIST_DIR}/src/helper.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ieee754.c
+	${CMAKE_CURRENT_LIST_DIR}/src/stream.c
 )
 list(APPEND CBOR_INCS ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/cbor.mk
+++ b/cbor.mk
@@ -11,5 +11,6 @@ CBOR_SRCS := \
 	$(cbor-basedir)src/encoder.c \
 	$(cbor-basedir)src/helper.c \
 	$(cbor-basedir)src/ieee754.c \
+	$(cbor-basedir)src/stream.c \
 
 CBOR_INCS := $(cbor-basedir)include

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -33,7 +33,7 @@ typedef enum {
 	CBOR_INVALID, /**< well-formed but invalid */
 	CBOR_OVERRUN, /**< more items than given buffer space */
 	CBOR_BREAK,
-	CBOR_EXCESSIVE, /**< recursion more than @ref CBOR_RECURSION_MAX_LEVEL */
+	CBOR_EXCESSIVE, /**< nesting exceeded implementation limits */
 	CBOR_NEED_MORE, /**< stream ended before item was complete */
 	CBOR_ABORTED,   /**< callback returned false; parsing stopped */
 } cbor_error_t;

--- a/include/cbor/base.h
+++ b/include/cbor/base.h
@@ -34,6 +34,8 @@ typedef enum {
 	CBOR_OVERRUN, /**< more items than given buffer space */
 	CBOR_BREAK,
 	CBOR_EXCESSIVE, /**< recursion more than @ref CBOR_RECURSION_MAX_LEVEL */
+	CBOR_NEED_MORE, /**< stream ended before item was complete */
+	CBOR_ABORTED,   /**< callback returned false; parsing stopped */
 } cbor_error_t;
 
 typedef enum {

--- a/include/cbor/cbor.h
+++ b/include/cbor/cbor.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "cbor/decoder.h"
 #include "cbor/encoder.h"
 #include "cbor/helper.h"
+#include "cbor/stream.h"
 
 #if defined(__cplusplus)
 }

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef CBOR_STREAM_H
+#define CBOR_STREAM_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include "cbor/base.h"
+
+typedef char cbor_stream_depth_must_fit_uint8_t[
+	(CBOR_RECURSION_MAX_LEVEL < 256) ? 1 : -1];
+
+#if !defined(CBOR_STREAM_MAX_PENDING_TAGS)
+/**
+ * Maximum number of consecutive tag prefixes before a tagged item.
+ * Attempting to open more returns CBOR_EXCESSIVE from cbor_stream_feed().
+ * Can be overridden at compile time.
+ */
+#define CBOR_STREAM_MAX_PENDING_TAGS 4
+#endif
+
+typedef enum {
+	CBOR_STREAM_EVENT_UINT,
+	CBOR_STREAM_EVENT_INT,
+	CBOR_STREAM_EVENT_BYTES,
+	CBOR_STREAM_EVENT_TEXT,
+	CBOR_STREAM_EVENT_ARRAY_START,
+	CBOR_STREAM_EVENT_ARRAY_END,
+	CBOR_STREAM_EVENT_MAP_START,
+	CBOR_STREAM_EVENT_MAP_END,
+	CBOR_STREAM_EVENT_FLOAT,
+	CBOR_STREAM_EVENT_BOOL,
+	CBOR_STREAM_EVENT_NULL,
+	CBOR_STREAM_EVENT_UNDEFINED,
+	CBOR_STREAM_EVENT_SIMPLE,
+	/**
+	 * A CBOR tag prefix.  Emitted immediately when the tag number is
+	 * decoded, before the wrapped item's event(s).  Nested tags produce
+	 * consecutive TAG events in outermost-to-innermost order.
+	 *
+	 * data->tag holds the tag number.
+	 */
+	CBOR_STREAM_EVENT_TAG,
+} cbor_stream_event_type_t;
+
+/**
+ * Structural context delivered with every event.
+ *
+ * Intentionally compact — fits in one or two registers on most targets.
+ * Does not carry tag information: tags arrive as separate TAG events that
+ * immediately precede the wrapped item's events.
+ */
+typedef struct {
+	cbor_stream_event_type_t type;
+	uint8_t  depth;       /**< nesting depth: 0 = top level */
+	bool     is_map_key;  /**< true when this item is a map key */
+} cbor_stream_event_t;
+
+/**
+ * Value payload — discriminated by event->type.
+ *
+ * NULL for _END events (container close has no payload).
+ */
+typedef union {
+	uint64_t uint;           /**< CBOR_STREAM_EVENT_UINT */
+	int64_t  sint;           /**< CBOR_STREAM_EVENT_INT */
+
+	struct {
+		const uint8_t *ptr;   /**< direct pointer into caller's chunk buffer */
+		size_t         len;   /**< bytes in this chunk */
+		int64_t        total; /**< declared total length; -1 if indefinite */
+		bool           first; /**< this is the first chunk */
+		bool           last;  /**< this is the last chunk */
+	} str;                    /**< CBOR_STREAM_EVENT_BYTES / _TEXT */
+
+	struct {
+		int64_t size; /**< declared item count; -1 if indefinite */
+	} container;      /**< CBOR_STREAM_EVENT_ARRAY/MAP_START */
+
+	double  flt;      /**< CBOR_STREAM_EVENT_FLOAT */
+	bool    boolean;  /**< CBOR_STREAM_EVENT_BOOL */
+	uint8_t simple;   /**< CBOR_STREAM_EVENT_SIMPLE */
+	uint64_t tag;     /**< CBOR_STREAM_EVENT_TAG — tag number */
+} cbor_stream_data_t;
+
+/**
+ * Streaming event callback.
+ *
+ * @param[in] event  structural context (type, depth, map position); never NULL
+ * @param[in] data   decoded value; NULL for _END events
+ * @param[in] arg    user-supplied context pointer
+ *
+ * @return true to continue decoding, false to abort (CBOR_ABORTED)
+ */
+typedef bool (*cbor_stream_callback_t)(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg);
+
+typedef struct {
+	cbor_item_data_t type;
+	int64_t          count; /**< remaining items; -1 = indefinite */
+	bool             is_key;
+} cbor_stream_frame_t;
+
+typedef struct {
+	/* ---- state machine ---- */
+	uint8_t state;                   /**< enum stream_state */
+	uint8_t major_type;
+	uint8_t additional_info;
+	uint8_t following_bytes;         /**< length descriptor bytes expected */
+	uint8_t following_bytes_read;    /**< length descriptor bytes received */
+	uint8_t length_buf[8];           /**< accumulation buffer for length/value */
+
+	int64_t payload_remaining;       /**< bytes left in current string payload */
+	int64_t payload_total;           /**< declared total for current string */
+	bool    payload_first_chunk;     /**< true until first chunk is emitted */
+
+	bool    in_indef_str;            /**< inside an indefinite-length string */
+	uint8_t indef_str_major;         /**< major type of the indef string (2 or 3) */
+
+	/* ---- pending tag state ---- */
+	uint8_t pending_tag_count;       /**< number of unresolved tag prefixes */
+
+	/* ---- container stack ---- */
+	cbor_stream_frame_t stack[CBOR_RECURSION_MAX_LEVEL];
+	uint8_t             depth;
+
+	/* ---- error state ---- */
+	cbor_error_t error;
+
+	/* ---- callback ---- */
+	cbor_stream_callback_t callback;
+	void                  *callback_arg;
+} cbor_stream_decoder_t;
+
+/**
+ * Initialize a streaming CBOR decoder.
+ *
+ * The decoder accepts zero or more consecutive top-level CBOR items
+ * (sequence semantics, per RFC 8742).  Callers that need "exactly one item"
+ * semantics should return false from the callback after the first complete
+ * top-level item (depth transitions back to 0).
+ *
+ * @param[in,out] decoder  decoder context allocated by caller (zeroed on init)
+ * @param[in]     callback event callback; if NULL, subsequent feed() calls
+ *                           return CBOR_INVALID
+ * @param[in]     arg      opaque pointer forwarded to every callback
+ */
+void cbor_stream_init(cbor_stream_decoder_t *decoder,
+		cbor_stream_callback_t callback, void *arg);
+
+/**
+ * Feed bytes into the decoder.
+ *
+ * May be called repeatedly with any chunk size >= 0 bytes.
+ * A zero-length feed is treated as a no-op; @p data may be NULL in that case.
+ * Partial items are held in decoder state and completed when more bytes arrive.
+ *
+ * After any non-CBOR_SUCCESS return the decoder enters a sticky error state;
+ * subsequent calls return the same error immediately without processing bytes.
+ * Call cbor_stream_reset() to clear the error and reuse the decoder.
+ *
+ * @param[in,out] decoder decoder context initialized by cbor_stream_init()
+ * @param[in]     data    pointer to bytes to consume (may be NULL if len == 0)
+ * @param[in]     len     number of bytes in @p data
+ *
+ * @return CBOR_SUCCESS   — all bytes processed, no error
+ *         CBOR_ILLEGAL   — malformed encoding (reserved additional-info); sticky
+ *         CBOR_INVALID   — well-formed but semantically invalid (e.g. null
+ *                          callback, negative integer exceeds int64 range); sticky
+ *         CBOR_EXCESSIVE — nesting depth or tag nesting exceeded limit; sticky
+ *         CBOR_ABORTED   — callback returned false; sticky
+ */
+cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
+		const void *data, size_t len);
+
+/**
+ * Signal end of input and verify the decoder is in a clean idle state.
+ *
+ * Does not invoke the callback.  Safe to call even when the decoder was
+ * initialized with a NULL callback.
+ *
+ * If the decoder is in a sticky error state (from a previous feed() call),
+ * this function returns that same error code without further processing.
+ *
+ * @param[in,out] decoder decoder context
+ *
+ * @return CBOR_INVALID   — @p decoder is NULL
+ *         CBOR_SUCCESS   — decoder is idle: all items complete and all
+ *                          containers closed (zero or more top-level items
+ *                          received)
+ *         CBOR_NEED_MORE — stream ended mid-item or with unclosed containers
+ *                          or pending tag prefix; more bytes needed
+ *         <sticky error> — the last non-success error from feed()
+ */
+cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder);
+
+/**
+ * Reset decoder to initial state, preserving the callback.
+ *
+ * @param[in,out] decoder decoder context
+ */
+void cbor_stream_reset(cbor_stream_decoder_t *decoder);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* CBOR_STREAM_H */

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -170,9 +170,12 @@ void cbor_stream_init(cbor_stream_decoder_t *decoder,
  * A zero-length feed is treated as a no-op; @p data may be NULL in that case.
  * Partial items are held in decoder state and completed when more bytes arrive.
  *
- * After any non-CBOR_SUCCESS return the decoder enters a sticky error state;
- * subsequent calls return the same error immediately without processing bytes.
- * Call cbor_stream_reset() to clear the error and reuse the decoder.
+ * After any non-CBOR_SUCCESS return produced while operating on a valid
+ * decoder instance, the decoder enters a sticky error state; subsequent calls
+ * return the same error immediately without processing bytes.  API-level
+ * argument validation failures (for example NULL decoder/callback, or NULL
+ * data with len > 0) return CBOR_INVALID but do not modify decoder state.
+ * Call cbor_stream_reset() to clear a sticky error and reuse the decoder.
  *
  * @param[in,out] decoder decoder context initialized by cbor_stream_init()
  * @param[in]     data    pointer to bytes to consume (may be NULL if len == 0)
@@ -180,8 +183,8 @@ void cbor_stream_init(cbor_stream_decoder_t *decoder,
  *
  * @return CBOR_SUCCESS   — all bytes processed, no error
  *         CBOR_ILLEGAL   — malformed encoding (reserved additional-info); sticky
- *         CBOR_INVALID   — well-formed but semantically invalid (e.g. null
- *                          callback, negative integer exceeds int64 range); sticky
+ *         CBOR_INVALID   — semantically invalid item, or invalid API arguments;
+ *                          sticky only for the former
  *         CBOR_EXCESSIVE — nesting depth or tag nesting exceeded limit; sticky
  *         CBOR_ABORTED   — callback returned false; sticky
  */

--- a/include/cbor/stream.h
+++ b/include/cbor/stream.h
@@ -72,12 +72,21 @@ typedef union {
 	int64_t  sint;           /**< CBOR_STREAM_EVENT_INT */
 
 	struct {
-		const uint8_t *ptr;   /**< direct pointer into caller's chunk buffer */
-		size_t         len;   /**< bytes in this chunk */
-		int64_t        total; /**< declared total length; -1 if indefinite */
-		bool           first; /**< this is the first chunk */
-		bool           last;  /**< this is the last chunk */
-	} str;                    /**< CBOR_STREAM_EVENT_BYTES / _TEXT */
+		const uint8_t *ptr;   /**< direct pointer into caller's chunk buffer,
+					 or NULL when len == 0 */
+		size_t         len;   /**< bytes in this chunk; may be 0 for empty
+					 strings and the final BREAK chunk of
+					 indefinite-length strings */
+		int64_t        total; /**< declared total length; -1 if indefinite,
+					 including the final BREAK chunk */
+		bool           first; /**< true for the first chunk; also true for
+					 the only empty chunk of a definite
+					 string */
+		bool           last;  /**< true for the final chunk; for
+					 indefinite-length strings this is the
+					 zero-length BREAK chunk */
+	} str;                    /**< CBOR_STREAM_EVENT_BYTES / _TEXT string data
+				      chunk */
 
 	struct {
 		int64_t size; /**< declared item count; -1 if indefinite */

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -40,6 +40,11 @@ static size_t count_strlen(char const *text, size_t maxlen)
 	return len;
 }
 
+static bool is_overrun(const cbor_writer_t *writer, size_t bytes_needed)
+{
+	return bytes_needed > (writer->bufsize - writer->bufidx);
+}
+
 static cbor_error_t encode_core(cbor_writer_t *writer, uint8_t major_type,
 		uint8_t const *data, uint64_t datasize, bool indefinite)
 {
@@ -59,7 +64,7 @@ static cbor_error_t encode_core(cbor_writer_t *writer, uint8_t major_type,
 		bytes_to_write -= (size_t)datasize;
 	}
 
-	if (bytes_to_write > (writer->bufsize - writer->bufidx)) {
+	if (is_overrun(writer, bytes_to_write)) {
 		return CBOR_OVERRUN;
 	}
 
@@ -184,11 +189,19 @@ static cbor_error_t encode_float(cbor_writer_t *writer, float value)
 	if (ieee754_is_shrinkable_to_half(value)) {
 		uint16_t half = ieee754_convert_single_to_half(value);
 
+		if (is_overrun(writer, 1u + sizeof(half))) {
+			return CBOR_OVERRUN;
+		}
+
 		writer->buf[writer->bufidx++] = 0xF9;
 		writer->bufidx += cbor_copy(&writer->buf[writer->bufidx],
 				(uint8_t const *)&half, sizeof(half));
 
 		return CBOR_SUCCESS;
+	}
+
+	if (is_overrun(writer, 1u + sizeof(value))) {
+		return CBOR_OVERRUN;
 	}
 
 	writer->buf[writer->bufidx++] = 0xFA;
@@ -207,6 +220,10 @@ cbor_error_t cbor_encode_double(cbor_writer_t *writer, double value)
 {
 	if (ieee754_is_shrinkable_to_single(value)) {
 		return encode_float(writer, (float)value);
+	}
+
+	if (is_overrun(writer, 1u + sizeof(value))) {
+		return CBOR_OVERRUN;
 	}
 
 	writer->buf[writer->bufidx++] = 0xFB;

--- a/src/helper.c
+++ b/src/helper.c
@@ -249,7 +249,7 @@ const char *cbor_stringify_error(cbor_error_t err)
 	case CBOR_BREAK:
 		return "break";
 	case CBOR_EXCESSIVE:
-		return "too deep recursion";
+		return "excessive nesting";
 	case CBOR_NEED_MORE:
 		return "need more data";
 	case CBOR_ABORTED:

--- a/src/helper.c
+++ b/src/helper.c
@@ -250,6 +250,10 @@ const char *cbor_stringify_error(cbor_error_t err)
 		return "break";
 	case CBOR_EXCESSIVE:
 		return "too deep recursion";
+	case CBOR_NEED_MORE:
+		return "need more data";
+	case CBOR_ABORTED:
+		return "aborted";
 	case CBOR_ILLEGAL: /* fall through */
 	default:
 		return "not well-formed";

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,0 +1,705 @@
+/*
+ * SPDX-FileCopyrightText: 2026 권경환 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "cbor/stream.h"
+#include "cbor/ieee754.h"
+
+#include <limits.h>
+#include <string.h>
+
+#if !defined(assert)
+#define assert(expr)
+#endif
+
+enum stream_state {
+	STREAM_STATE_IDLE    = 0,
+	STREAM_STATE_LENGTH  = 1,
+	STREAM_STATE_PAYLOAD = 2,
+	STREAM_STATE_ERROR   = 3,
+};
+
+static bool can_fit_int64(uint64_t value)
+{
+	return value <= (uint64_t)INT64_MAX;
+}
+
+static void build_event(const cbor_stream_decoder_t *d,
+		cbor_stream_event_type_t type, cbor_stream_event_t *event)
+{
+	event->type = type;
+	event->depth = d->depth;
+	event->is_map_key = (d->depth > 0) &&
+		(d->stack[d->depth - 1].type == CBOR_ITEM_MAP) &&
+		d->stack[d->depth - 1].is_key;
+}
+
+static cbor_error_t invoke_cb(cbor_stream_decoder_t *d,
+		const cbor_stream_event_t *event, const cbor_stream_data_t *data)
+{
+	if (!d->callback(event, data, d->callback_arg)) {
+		d->error = CBOR_ABORTED;
+		d->state = STREAM_STATE_ERROR;
+		return CBOR_ABORTED;
+	}
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t emit_tag(cbor_stream_decoder_t *d, uint64_t tag_number)
+{
+	if (d->pending_tag_count >= CBOR_STREAM_MAX_PENDING_TAGS) {
+		return CBOR_EXCESSIVE;
+	}
+
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+
+	build_event(d, CBOR_STREAM_EVENT_TAG, &event);
+	data.tag = tag_number;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+
+	d->pending_tag_count++;
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t emit_container_end(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_event_type_t type;
+
+	d->depth--;
+	type = (d->stack[d->depth].type == CBOR_ITEM_ARRAY)
+		? CBOR_STREAM_EVENT_ARRAY_END : CBOR_STREAM_EVENT_MAP_END;
+	build_event(d, type, &event);
+	return invoke_cb(d, &event, NULL);
+}
+
+static cbor_error_t after_item(cbor_stream_decoder_t *d)
+{
+	while (d->depth > 0) {
+		cbor_stream_frame_t *f = &d->stack[d->depth - 1];
+
+		if (f->type == CBOR_ITEM_MAP) {
+			f->is_key = !f->is_key;
+		}
+
+		if (f->count < 0) {
+			/* indefinite: wait for BREAK */
+			break;
+		}
+
+		if (f->count > 1) {
+			f->count--;
+			break;
+		}
+
+		f->count--; /* reaches 0: emit END */
+
+		cbor_error_t err = emit_container_end(d);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		/* continue to cascade up */
+	}
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t push_container(cbor_stream_decoder_t *d,
+		cbor_item_data_t type, int64_t count)
+{
+	if (d->depth >= CBOR_RECURSION_MAX_LEVEL) {
+		return CBOR_EXCESSIVE;
+	}
+
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+	cbor_stream_event_type_t evtype = (type == CBOR_ITEM_ARRAY)
+		? CBOR_STREAM_EVENT_ARRAY_START : CBOR_STREAM_EVENT_MAP_START;
+
+	build_event(d, evtype, &event);
+	data.container.size = (type == CBOR_ITEM_MAP && count >= 0)
+		? (count / 2) : count;
+
+	/* clear pending tags before emitting START — tags were already
+	 * delivered as TAG events; this START is the "wrapped item" */
+	d->pending_tag_count = 0;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+
+	cbor_stream_frame_t *f = &d->stack[d->depth];
+	f->type   = type;
+	f->count  = count;
+	f->is_key = (type == CBOR_ITEM_MAP);
+	d->depth++;
+
+	if (count == 0) {
+		err = emit_container_end(d);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		return after_item(d);
+	}
+
+	return CBOR_SUCCESS;
+}
+
+static uint64_t decode_length_buf(const cbor_stream_decoder_t *d)
+{
+	uint64_t val = 0;
+	for (uint8_t i = 0; i < d->following_bytes; i++) {
+		val = (val << 8) | d->length_buf[i];
+	}
+	return val;
+}
+
+static uint64_t get_item_value(const cbor_stream_decoder_t *d)
+{
+	if (d->following_bytes == 0) {
+		return d->additional_info;
+	}
+	return decode_length_buf(d);
+}
+
+static double decode_float_value(const cbor_stream_decoder_t *d)
+{
+	uint64_t raw = decode_length_buf(d);
+
+	if (d->following_bytes == 2) {
+		return ieee754_convert_half_to_double((uint16_t)raw);
+	} else if (d->following_bytes == 4) {
+		uint32_t u32 = (uint32_t)raw;
+		float f;
+		memcpy(&f, &u32, 4);
+		return (double)f;
+	} else {
+		double dbl;
+		memcpy(&dbl, &raw, 8);
+		return dbl;
+	}
+}
+
+static cbor_error_t emit_uint(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+
+	build_event(d, CBOR_STREAM_EVENT_UINT, &event);
+	data.uint = get_item_value(d);
+	d->pending_tag_count = 0;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_int(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+	uint64_t raw = get_item_value(d);
+
+	if (!can_fit_int64(raw)) {
+		return CBOR_INVALID;
+	}
+
+	build_event(d, CBOR_STREAM_EVENT_INT, &event);
+	data.sint = -(int64_t)raw - 1;
+	d->pending_tag_count = 0;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_str_chunk(cbor_stream_decoder_t *d,
+		cbor_stream_event_type_t type,
+		const uint8_t *ptr, size_t len, bool first, bool last)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+
+	build_event(d, type, &event);
+	data.str.ptr   = ptr;
+	data.str.len   = len;
+	data.str.total = d->payload_total;
+	data.str.first = first;
+	data.str.last  = last;
+
+	/* clear pending tags on the first chunk — this is the wrapped item start */
+	if (first) {
+		d->pending_tag_count = 0;
+	}
+
+	return invoke_cb(d, &event, &data);
+}
+
+static cbor_error_t emit_simple(cbor_stream_decoder_t *d, uint8_t val)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+	cbor_error_t        err;
+
+	switch (val) {
+	case 20:
+		build_event(d, CBOR_STREAM_EVENT_BOOL, &event);
+		data.boolean = false;
+		break;
+	case 21:
+		build_event(d, CBOR_STREAM_EVENT_BOOL, &event);
+		data.boolean = true;
+		break;
+	case 22:
+		build_event(d, CBOR_STREAM_EVENT_NULL, &event);
+		break;
+	case 23:
+		build_event(d, CBOR_STREAM_EVENT_UNDEFINED, &event);
+		break;
+	default:
+		build_event(d, CBOR_STREAM_EVENT_SIMPLE, &event);
+		data.simple = val;
+		break;
+	}
+
+	d->pending_tag_count = 0;
+
+	err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t emit_float(cbor_stream_decoder_t *d)
+{
+	cbor_stream_event_t event;
+	cbor_stream_data_t  data = {0};
+
+	build_event(d, CBOR_STREAM_EVENT_FLOAT, &event);
+	data.flt = decode_float_value(d);
+	d->pending_tag_count = 0;
+
+	cbor_error_t err = invoke_cb(d, &event, &data);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t handle_break(cbor_stream_decoder_t *d)
+{
+	if (d->in_indef_str) {
+		cbor_stream_event_type_t type = (d->indef_str_major == 2)
+			? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+		/* empty indef string: payload_first_chunk is still true;
+		 * emit_str_chunk with first=true clears pending_tag_count */
+		cbor_error_t err = emit_str_chunk(d, type, NULL, 0,
+				d->payload_first_chunk, true);
+		d->in_indef_str = false;
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		return after_item(d);
+	}
+
+	if (d->depth == 0 || d->stack[d->depth - 1].count >= 0) {
+		return CBOR_ILLEGAL;
+	}
+
+	if (d->pending_tag_count > 0) {
+		return CBOR_ILLEGAL;
+	}
+
+	if (d->stack[d->depth - 1].type == CBOR_ITEM_MAP &&
+			!d->stack[d->depth - 1].is_key) {
+		return CBOR_ILLEGAL;
+	}
+
+	/* indefinite container terminated by BREAK */
+	cbor_error_t err = emit_container_end(d);
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+	return after_item(d);
+}
+
+static cbor_error_t process_immediate(cbor_stream_decoder_t *d)
+{
+	cbor_error_t err;
+
+	switch (d->major_type) {
+	case 0: /* unsigned integer */
+		return emit_uint(d);
+	case 1: /* negative integer */
+		return emit_int(d);
+	case 2: /* byte string, length in additional_info */
+	case 3: /* text string, length in additional_info */ {
+		cbor_stream_event_type_t stype = (d->major_type == 2)
+			? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+		uint64_t slen = (uint64_t)d->additional_info;
+
+		if (!d->in_indef_str) {
+			d->payload_total       = (int64_t)slen;
+			d->payload_first_chunk = true;
+		}
+
+		if (slen == 0) {
+			bool first = d->in_indef_str ? d->payload_first_chunk : true;
+			bool last  = !d->in_indef_str;
+			d->payload_first_chunk = false;
+			err = emit_str_chunk(d, stype, NULL, 0, first, last);
+			if (err != CBOR_SUCCESS) {
+				return err;
+			}
+			if (!d->in_indef_str) {
+				return after_item(d);
+			}
+			return CBOR_SUCCESS;
+		}
+
+		d->payload_remaining = (int64_t)slen;
+		d->state = STREAM_STATE_PAYLOAD;
+		return CBOR_SUCCESS;
+	}
+	case 4: /* definite array */
+		return push_container(d, CBOR_ITEM_ARRAY,
+				(int64_t)d->additional_info);
+	case 5: /* definite map */
+		return push_container(d, CBOR_ITEM_MAP,
+				(int64_t)(d->additional_info * 2));
+	case 6: /* tag, value in additional_info */
+		return emit_tag(d, (uint64_t)d->additional_info);
+	case 7: /* simple value (additional_info 0-23) */
+		/* additional_info >= 24 has following_bytes > 0, handled elsewhere;
+		 * additional_info == 31 (BREAK) is caught by handle_indefinite() */
+		return emit_simple(d, d->additional_info);
+	default:
+		return CBOR_ILLEGAL;
+	}
+}
+
+static cbor_error_t process_string_length(cbor_stream_decoder_t *d)
+{
+	uint64_t len = decode_length_buf(d);
+	cbor_stream_event_type_t type = (d->major_type == 2)
+		? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+
+	/* for indefinite-string sub-chunks keep payload_total as -1 */
+	if (!d->in_indef_str) {
+		if (!can_fit_int64(len)) {
+			return CBOR_INVALID;
+		}
+		d->payload_total = (int64_t)len;
+	}
+
+	if (len == 0) {
+		bool first = d->in_indef_str ? d->payload_first_chunk : true;
+		bool last  = !d->in_indef_str;
+		d->payload_first_chunk = false;
+		cbor_error_t err = emit_str_chunk(d, type, NULL, 0, first, last);
+		if (err != CBOR_SUCCESS) {
+			return err;
+		}
+		if (!d->in_indef_str) {
+			return after_item(d);
+		}
+		return CBOR_SUCCESS;
+	}
+
+	if (!can_fit_int64(len)) {
+		return CBOR_INVALID;
+	}
+
+	d->payload_remaining   = (int64_t)len;
+	d->payload_first_chunk = d->in_indef_str ? d->payload_first_chunk : true;
+	d->state = STREAM_STATE_PAYLOAD;
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t process_container_length(cbor_stream_decoder_t *d)
+{
+	uint64_t n = decode_length_buf(d);
+	cbor_item_data_t type = (d->major_type == 4)
+		? CBOR_ITEM_ARRAY : CBOR_ITEM_MAP;
+	int64_t count;
+
+	if (type == CBOR_ITEM_MAP) {
+		if (n > (uint64_t)(INT64_MAX / 2)) {
+			return CBOR_INVALID;
+		}
+		count = (int64_t)(n * 2u);
+	} else {
+		if (!can_fit_int64(n)) {
+			return CBOR_INVALID;
+		}
+		count = (int64_t)n;
+	}
+
+	return push_container(d, type, count);
+}
+
+static cbor_error_t process_tag_length(cbor_stream_decoder_t *d)
+{
+	cbor_error_t err = emit_tag(d, decode_length_buf(d));
+	d->state = STREAM_STATE_IDLE;
+	return err;
+}
+
+static cbor_error_t process_float_simple_length(cbor_stream_decoder_t *d)
+{
+	if (d->following_bytes == 1) {
+		/* 1 following byte → simple value */
+		return emit_simple(d, d->length_buf[0]);
+	}
+	return emit_float(d);
+}
+
+static cbor_error_t process_length_complete(cbor_stream_decoder_t *d)
+{
+	cbor_error_t err;
+
+	d->state = STREAM_STATE_IDLE;
+
+	switch (d->major_type) {
+	case 0: err = emit_uint(d); break;
+	case 1: err = emit_int(d); break;
+	case 2: /* fall-through */
+	case 3: err = process_string_length(d); break;
+	case 4: /* fall-through */
+	case 5: err = process_container_length(d); break;
+	case 6: err = process_tag_length(d); break;
+	case 7: err = process_float_simple_length(d); break;
+	default: err = CBOR_ILLEGAL; break;
+	}
+
+	d->following_bytes = 0;
+	d->following_bytes_read = 0;
+	return err;
+}
+
+static cbor_error_t handle_indefinite(cbor_stream_decoder_t *d)
+{
+	switch (d->major_type) {
+	case 2: /* indefinite byte string */
+	case 3: /* indefinite text string */
+		if (d->in_indef_str) {
+			return CBOR_ILLEGAL; /* no nesting of indef strings */
+		}
+		d->in_indef_str        = true;
+		d->indef_str_major     = d->major_type;
+		d->payload_first_chunk = true;
+		d->payload_total       = -1;
+		d->state = STREAM_STATE_IDLE;
+		return CBOR_SUCCESS;
+
+	case 4: /* indefinite array */
+		return push_container(d, CBOR_ITEM_ARRAY, -1);
+
+	case 5: /* indefinite map */
+		return push_container(d, CBOR_ITEM_MAP, -1);
+
+	case 7: /* BREAK */
+		return handle_break(d);
+
+	default:
+		return CBOR_ILLEGAL;
+	}
+}
+
+static cbor_error_t process_initial_byte(cbor_stream_decoder_t *d, uint8_t b)
+{
+	d->major_type      = b >> 5;
+	d->additional_info = b & 0x1fu;
+	d->following_bytes = cbor_get_following_bytes(d->additional_info);
+
+	if (d->following_bytes == (uint8_t)CBOR_RESERVED_VALUE) {
+		return CBOR_ILLEGAL;
+	}
+
+	if (d->in_indef_str) {
+		/* inside indefinite string: only BREAK or same-major sub-chunks */
+		if (b == 0xff) {
+			return handle_break(d);
+		}
+		if (d->major_type != d->indef_str_major) {
+			return CBOR_ILLEGAL;
+		}
+		if (d->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
+			return CBOR_ILLEGAL; /* no nested indefinite */
+		}
+	}
+
+	if (d->following_bytes == (uint8_t)CBOR_INDEFINITE_VALUE) {
+		return handle_indefinite(d);
+	}
+
+	if (d->following_bytes == 0) {
+		return process_immediate(d);
+	}
+
+	/* need to read following_bytes bytes */
+	d->following_bytes_read = 0;
+	memset(d->length_buf, 0, sizeof(d->length_buf));
+	d->state = STREAM_STATE_LENGTH;
+	return CBOR_SUCCESS;
+}
+
+static cbor_error_t consume_payload(cbor_stream_decoder_t *d,
+		const uint8_t **p, size_t *remaining)
+{
+	if (d->payload_remaining <= 0) {
+		return CBOR_INVALID;
+	}
+
+	size_t avail = *remaining;
+	if (d->payload_remaining < (int64_t)avail) {
+		avail = (size_t)d->payload_remaining;
+	}
+
+	cbor_stream_event_type_t type = (d->major_type == 2)
+		? CBOR_STREAM_EVENT_BYTES : CBOR_STREAM_EVENT_TEXT;
+	bool last = ((int64_t)avail == d->payload_remaining) && !d->in_indef_str;
+
+	cbor_error_t err = emit_str_chunk(d, type, *p, avail,
+			d->payload_first_chunk, last);
+	d->payload_first_chunk = false;
+
+	*p               += avail;
+	*remaining       -= avail;
+	d->payload_remaining -= (int64_t)avail;
+
+	if (err != CBOR_SUCCESS) {
+		return err;
+	}
+
+	if (d->payload_remaining > 0) {
+		return CBOR_SUCCESS; /* still in PAYLOAD state */
+	}
+
+	d->state = STREAM_STATE_IDLE;
+
+	if (!d->in_indef_str) {
+		return after_item(d);
+	}
+	/* sub-chunk done; stay in in_indef_str mode */
+	return CBOR_SUCCESS;
+}
+
+void cbor_stream_init(cbor_stream_decoder_t *decoder,
+		cbor_stream_callback_t callback, void *arg)
+{
+	assert(decoder != NULL);
+
+	if (decoder == NULL) {
+		return;
+	}
+
+	memset(decoder, 0, sizeof(*decoder));
+	decoder->callback     = callback;
+	decoder->callback_arg = arg;
+	decoder->state        = STREAM_STATE_IDLE;
+}
+
+cbor_error_t cbor_stream_feed(cbor_stream_decoder_t *decoder,
+		const void *data, size_t len)
+{
+	if (decoder == NULL || decoder->callback == NULL) {
+		return CBOR_INVALID;
+	}
+
+	if (len > 0 && data == NULL) {
+		return CBOR_INVALID;
+	}
+
+	if (decoder->state == STREAM_STATE_ERROR) {
+		return decoder->error;
+	}
+
+	const uint8_t *p         = (const uint8_t *)data;
+	size_t         remaining  = len;
+	cbor_error_t   err        = CBOR_SUCCESS;
+
+	while (remaining > 0) {
+		switch (decoder->state) {
+		case STREAM_STATE_IDLE:
+			err = process_initial_byte(decoder, *p);
+			p++;
+			remaining--;
+			break;
+
+		case STREAM_STATE_LENGTH:
+			decoder->length_buf[decoder->following_bytes_read++] = *p;
+			p++;
+			remaining--;
+			if (decoder->following_bytes_read == decoder->following_bytes) {
+				err = process_length_complete(decoder);
+			}
+			break;
+
+		case STREAM_STATE_PAYLOAD:
+			err = consume_payload(decoder, &p, &remaining);
+			break;
+
+		case STREAM_STATE_ERROR:
+			return decoder->error;
+		default:
+			return CBOR_ILLEGAL;
+		}
+
+		if (err != CBOR_SUCCESS) {
+			decoder->error = err;
+			decoder->state = STREAM_STATE_ERROR;
+			return err;
+		}
+	}
+
+	return CBOR_SUCCESS;
+}
+
+cbor_error_t cbor_stream_finish(cbor_stream_decoder_t *decoder)
+{
+	if (decoder == NULL) {
+		return CBOR_INVALID;
+	}
+
+	if (decoder->state == STREAM_STATE_ERROR) {
+		return decoder->error;
+	}
+
+	if (decoder->state != STREAM_STATE_IDLE || decoder->depth > 0 ||
+			decoder->in_indef_str ||
+			decoder->following_bytes_read > 0 ||
+			decoder->pending_tag_count > 0) {
+		return CBOR_NEED_MORE;
+	}
+
+	return CBOR_SUCCESS;
+}
+
+void cbor_stream_reset(cbor_stream_decoder_t *decoder)
+{
+	assert(decoder != NULL);
+
+	if (decoder == NULL) {
+		return;
+	}
+
+	cbor_stream_callback_t cb  = decoder->callback;
+	void                  *arg = decoder->callback_arg;
+	memset(decoder, 0, sizeof(*decoder));
+	decoder->callback     = cb;
+	decoder->callback_arg = arg;
+	decoder->state        = STREAM_STATE_IDLE;
+}

--- a/tests/runners/stream.mk
+++ b/tests/runners/stream.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = stream
+
+SRC_FILES = \
+	../src/stream.c \
+	../src/common.c \
+	../src/ieee754.c \
+
+TEST_SRC_FILES = \
+	src/stream_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+
+include MakefileRunner.mk

--- a/tests/src/encoder_test.cpp
+++ b/tests/src/encoder_test.cpp
@@ -525,3 +525,48 @@ TEST(Encoder, ShouldReturnOverrun_WhenNullTerminatedTextDoesNotFit) {
 	LONGS_EQUAL(0, small_writer.bufidx);
 	MEMCMP_EQUAL(before, small_buffer, sizeof(before));
 }
+
+TEST(Encoder, ShouldReturnOverrun_WhenHalfFloatDoesNotFit) {
+	cbor_writer_t small_writer;
+	uint8_t small_buffer[2]; /* half-float needs 3 bytes */
+	uint8_t before[sizeof(small_buffer)];
+
+	memset(small_buffer, 0xA5, sizeof(small_buffer));
+	memcpy(before, small_buffer, sizeof(before));
+	cbor_writer_init(&small_writer, small_buffer, sizeof(small_buffer));
+
+	/* 1.0f is shrinkable to half-float */
+	LONGS_EQUAL(CBOR_OVERRUN, cbor_encode_float(&small_writer, 1.0f));
+	LONGS_EQUAL(0, small_writer.bufidx);
+	MEMCMP_EQUAL(before, small_buffer, sizeof(before));
+}
+
+TEST(Encoder, ShouldReturnOverrun_WhenSingleFloatDoesNotFit) {
+	cbor_writer_t small_writer;
+	uint8_t small_buffer[4]; /* single-float needs 5 bytes */
+	uint8_t before[sizeof(small_buffer)];
+
+	memset(small_buffer, 0xA5, sizeof(small_buffer));
+	memcpy(before, small_buffer, sizeof(before));
+	cbor_writer_init(&small_writer, small_buffer, sizeof(small_buffer));
+
+	/* 1.1f is not shrinkable to half-float */
+	LONGS_EQUAL(CBOR_OVERRUN, cbor_encode_float(&small_writer, 1.1f));
+	LONGS_EQUAL(0, small_writer.bufidx);
+	MEMCMP_EQUAL(before, small_buffer, sizeof(before));
+}
+
+TEST(Encoder, ShouldReturnOverrun_WhenDoubleDoesNotFit) {
+	cbor_writer_t small_writer;
+	uint8_t small_buffer[8]; /* double needs 9 bytes */
+	uint8_t before[sizeof(small_buffer)];
+
+	memset(small_buffer, 0xA5, sizeof(small_buffer));
+	memcpy(before, small_buffer, sizeof(before));
+	cbor_writer_init(&small_writer, small_buffer, sizeof(small_buffer));
+
+	/* 1.1 (double) is not shrinkable to single */
+	LONGS_EQUAL(CBOR_OVERRUN, cbor_encode_double(&small_writer, 1.1));
+	LONGS_EQUAL(0, small_writer.bufidx);
+	MEMCMP_EQUAL(before, small_buffer, sizeof(before));
+}

--- a/tests/src/helper_test.cpp
+++ b/tests/src/helper_test.cpp
@@ -338,3 +338,8 @@ TEST(Helper, unmarshal_ShouldInvokeCallbacks_WhenIndefiniteMapGiven)
 					 sizeof(parsers) / sizeof(*parsers),
 					 msg, sizeof(msg), nullptr));
 }
+
+TEST(Helper, ShouldStringifyExcessiveWhenLimitExceeded)
+{
+	STRCMP_EQUAL("excessive nesting", cbor_stringify_error(CBOR_EXCESSIVE));
+}

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -1,0 +1,1281 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Kyunghwan Kwon <k@mononn.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "cbor/stream.h"
+#include <stdint.h>
+#include <string.h>
+
+/* ---------- test helpers ---------- */
+
+struct RecordedEvent {
+	cbor_stream_event_type_t type;
+	uint8_t  depth;
+	bool     is_map_key;
+
+	/* scalar and tag payloads (uint_val also stores tag numbers) */
+	uint64_t uint_val;
+	int64_t  sint_val;
+	double   flt_val;
+	bool     bool_val;
+	uint8_t  simple_val;
+
+	/* string fields */
+	uint8_t  str_buf[256];
+	size_t   str_len;
+	int64_t  str_total;
+	bool     str_first;
+	bool     str_last;
+
+	/* container size */
+	int64_t container_size;
+};
+
+static const int MAX_EVENTS = 64;
+
+struct Recorder {
+	RecordedEvent events[MAX_EVENTS];
+	int           count;
+	bool          abort_after_first;
+	int           abort_at; /**< abort when count reaches this value */
+};
+
+struct ZeroLengthGuard {
+	int    text_events;
+	size_t last_len;
+	bool   saw_zero_len;
+};
+
+static bool record_cb(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg)
+{
+	Recorder *r = (Recorder *)arg;
+
+	if (r->abort_after_first && r->count >= r->abort_at) {
+		return false;
+	}
+
+	if (r->count >= MAX_EVENTS) {
+		return true;
+	}
+
+	RecordedEvent &ev = r->events[r->count++];
+	memset(&ev, 0, sizeof(ev));
+	ev.type       = event->type;
+	ev.depth      = event->depth;
+	ev.is_map_key = event->is_map_key;
+
+	if (!data) {
+		return true;
+	}
+
+	switch (event->type) {
+	case CBOR_STREAM_EVENT_TAG:
+		ev.uint_val = data->tag; /* reuse uint_val for tag number */
+		break;
+	case CBOR_STREAM_EVENT_UINT:
+		ev.uint_val = data->uint;
+		break;
+	case CBOR_STREAM_EVENT_INT:
+		ev.sint_val = data->sint;
+		break;
+	case CBOR_STREAM_EVENT_FLOAT:
+		ev.flt_val = data->flt;
+		break;
+	case CBOR_STREAM_EVENT_BOOL:
+		ev.bool_val = data->boolean;
+		break;
+	case CBOR_STREAM_EVENT_SIMPLE:
+		ev.simple_val = data->simple;
+		break;
+	case CBOR_STREAM_EVENT_BYTES:
+	case CBOR_STREAM_EVENT_TEXT:
+		ev.str_total = data->str.total;
+		ev.str_first = data->str.first;
+		ev.str_last  = data->str.last;
+		ev.str_len   = data->str.len;
+		if (data->str.ptr && data->str.len <= sizeof(ev.str_buf)) {
+			memcpy(ev.str_buf, data->str.ptr, data->str.len);
+		}
+		break;
+	case CBOR_STREAM_EVENT_ARRAY_START:
+	case CBOR_STREAM_EVENT_MAP_START:
+		ev.container_size = data->container.size;
+		break;
+	case CBOR_STREAM_EVENT_ARRAY_END:
+	case CBOR_STREAM_EVENT_MAP_END:
+	case CBOR_STREAM_EVENT_NULL:
+	case CBOR_STREAM_EVENT_UNDEFINED:
+	default:
+		break;
+	}
+
+	return true;
+}
+
+static bool reject_zero_length_text_cb(const cbor_stream_event_t *event,
+		const cbor_stream_data_t *data, void *arg)
+{
+	ZeroLengthGuard *guard = (ZeroLengthGuard *)arg;
+
+	if (event->type != CBOR_STREAM_EVENT_TEXT || data == NULL) {
+		return true;
+	}
+
+	guard->text_events++;
+	guard->last_len = data->str.len;
+	guard->saw_zero_len = (data->str.len == 0);
+
+	return !guard->saw_zero_len;
+}
+
+static void feed_all(cbor_stream_decoder_t *d, const uint8_t *buf, size_t len)
+{
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(d, buf, len));
+}
+
+/* Feed one byte at a time to stress the streaming logic */
+static void feed_byte_by_byte(cbor_stream_decoder_t *d,
+		const uint8_t *buf, size_t len)
+{
+	for (size_t i = 0; i < len; i++) {
+		LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(d, &buf[i], 1));
+	}
+}
+
+/* ---------- TEST_GROUP: Integers ---------- */
+
+TEST_GROUP(StreamInteger)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamInteger, ShouldEmitUint_WhenSmallUintGiven)
+{
+	uint8_t msg[] = { 0x05 }; /* uint 5 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGLONGS_EQUAL(5ull, rec.events[0].uint_val);
+	LONGS_EQUAL(0, rec.events[0].depth);
+}
+
+TEST(StreamInteger, ShouldEmitUint_WhenOneByteLengthGiven)
+{
+	uint8_t msg[] = { 0x18, 0xff }; /* uint 255 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGLONGS_EQUAL(255ull, rec.events[0].uint_val);
+}
+
+TEST(StreamInteger, ShouldEmitUint_WhenTwoByteLengthGiven)
+{
+	uint8_t msg[] = { 0x19, 0x01, 0x00 }; /* uint 256 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGLONGS_EQUAL(256ull, rec.events[0].uint_val);
+}
+
+TEST(StreamInteger, ShouldEmitNegInt_WhenNegativeIntegerGiven)
+{
+	uint8_t msg[] = { 0x20 }; /* -1 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].sint_val);
+}
+
+TEST(StreamInteger, ShouldEmitNegInt_WhenNeg100Given)
+{
+	uint8_t msg[] = { 0x38, 0x63 }; /* -100 */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_INT, rec.events[0].type);
+	LONGLONGS_EQUAL(-100ll, rec.events[0].sint_val);
+}
+
+TEST(StreamInteger, ShouldEmitMultipleUints_WhenFedByteByByte)
+{
+	uint8_t msg[] = { 0x01, 0x02, 0x03 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(3, rec.count);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGLONGS_EQUAL(2ull, rec.events[1].uint_val);
+	LONGLONGS_EQUAL(3ull, rec.events[2].uint_val);
+}
+
+/* ---------- TEST_GROUP: Strings ---------- */
+
+TEST_GROUP(StreamString)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamString, ShouldEmitEmptyTextString_WhenZeroLengthTextGiven)
+{
+	uint8_t msg[] = { 0x60 }; /* "" */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].str_len);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamString, ShouldEmitTextString_WhenShortTextGiven)
+{
+	/* "a" = 0x61 0x61 */
+	uint8_t msg[] = { 0x61, 0x61 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
+	LONGS_EQUAL(1, rec.events[0].str_len);
+	LONGS_EQUAL('a', rec.events[0].str_buf[0]);
+	LONGLONGS_EQUAL(1ll, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamString, ShouldEmitTextString_WhenFedByteByByte)
+{
+	/* "hello" */
+	uint8_t msg[] = { 0x65, 'h', 'e', 'l', 'l', 'o' };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	/* may arrive in multiple chunks; total content matters */
+	size_t total_len = 0;
+	for (int i = 0; i < rec.count; i++) {
+		total_len += rec.events[i].str_len;
+	}
+	LONGS_EQUAL(5, total_len);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[rec.count - 1].str_last);
+}
+
+TEST(StreamString, ShouldEmitByteString_WhenByteStringGiven)
+{
+	uint8_t msg[] = { 0x43, 0xAA, 0xBB, 0xCC }; /* h'aabbcc' */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(3, rec.events[0].str_len);
+	LONGS_EQUAL(0xAA, rec.events[0].str_buf[0]);
+}
+
+TEST(StreamString, ShouldEmitChunks_WhenPayloadSplitAcrossFeeds)
+{
+	/* 5-byte text "hello" split into 3+2 */
+	uint8_t header[] = { 0x65 };
+	uint8_t part1[]  = { 'h', 'e', 'l' };
+	uint8_t part2[]  = { 'l', 'o' };
+
+	feed_all(&decoder, header, sizeof(header));
+	feed_all(&decoder, part1, sizeof(part1));
+	feed_all(&decoder, part2, sizeof(part2));
+
+	CHECK(rec.count >= 1);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[rec.count - 1].str_last);
+}
+
+/* ---------- TEST_GROUP: Indefinite Strings ---------- */
+
+TEST_GROUP(StreamIndefString)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamIndefString, ShouldEmitSingleBreakChunk_WhenEmptyIndefStringGiven)
+{
+	/* (_ ) = 0x5f 0xff */
+	uint8_t msg[] = { 0x5f, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].str_len);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[0].str_last);
+}
+
+TEST(StreamIndefString, ShouldEmitSubChunkThenBreak_WhenIndefStringWithDataGiven)
+{
+	/* (_ h'0102') = 0x5f 0x42 0x01 0x02 0xff */
+	uint8_t msg[] = { 0x5f, 0x42, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+
+	/* first sub-chunk */
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
+	LONGS_EQUAL(2, rec.events[0].str_len);
+	LONGS_EQUAL(0x01, rec.events[0].str_buf[0]);
+	LONGS_EQUAL(0x02, rec.events[0].str_buf[1]);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].str_total);
+	CHECK(rec.events[0].str_first);
+	CHECK(!rec.events[0].str_last);
+
+	/* BREAK chunk */
+	LONGS_EQUAL(0, rec.events[1].str_len);
+	CHECK(!rec.events[1].str_first);
+	CHECK(rec.events[1].str_last);
+}
+
+TEST(StreamIndefString, ShouldEmitTextChunks_WhenIndefTextStringGiven)
+{
+	/* (_ "fo" "o") = 0x7f 0x62 0x66 0x6f 0x61 0x6f 0xff */
+	uint8_t msg[] = { 0x7f, 0x62, 'f', 'o', 0x61, 'o', 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(3, rec.count);
+	for (int i = 0; i < 3; i++) {
+		LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[i].type);
+	}
+	CHECK(rec.events[0].str_first);
+	CHECK(rec.events[2].str_last);
+	LONGS_EQUAL(0, rec.events[2].str_len); /* BREAK chunk */
+}
+
+TEST(StreamIndefString, ShouldReturnIllegal_WhenWrongMajorTypeInIndefString)
+{
+	/* 0x5f followed by a text string chunk instead of byte string */
+	uint8_t msg[] = { 0x5f, 0x61, 0x61 };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+/* ---------- TEST_GROUP: Simple / Float / Bool ---------- */
+
+TEST_GROUP(StreamSimple)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamSimple, ShouldEmitTrue_WhenTrueGiven)
+{
+	uint8_t msg[] = { 0xf5 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BOOL, rec.events[0].type);
+	CHECK(rec.events[0].bool_val);
+}
+
+TEST(StreamSimple, ShouldEmitFalse_WhenFalseGiven)
+{
+	uint8_t msg[] = { 0xf4 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BOOL, rec.events[0].type);
+	CHECK(!rec.events[0].bool_val);
+}
+
+TEST(StreamSimple, ShouldEmitNull_WhenNullGiven)
+{
+	uint8_t msg[] = { 0xf6 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_NULL, rec.events[0].type);
+}
+
+TEST(StreamSimple, ShouldEmitUndefined_WhenUndefinedGiven)
+{
+	uint8_t msg[] = { 0xf7 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UNDEFINED, rec.events[0].type);
+}
+
+TEST(StreamSimple, ShouldEmitSimple_WhenUnassignedSimpleValueGiven)
+{
+	uint8_t msg[] = { 0xe0 }; /* simple(0) */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_SIMPLE, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].simple_val);
+}
+
+TEST(StreamSimple, ShouldEmitFloat_WhenHalfPrecisionFloatGiven)
+{
+	/* 1.0 in half precision = 0xf9 0x3c 0x00 */
+	uint8_t msg[] = { 0xf9, 0x3c, 0x00 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_FLOAT, rec.events[0].type);
+	DOUBLES_EQUAL(1.0, rec.events[0].flt_val, 1e-6);
+}
+
+TEST(StreamSimple, ShouldEmitFloat_WhenSinglePrecisionFloatGiven)
+{
+	uint8_t msg[] = { 0xfa, 0x40, 0x48, 0xf5, 0xc3 }; /* 3.14f */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_FLOAT, rec.events[0].type);
+	DOUBLES_EQUAL(3.14, rec.events[0].flt_val, 1e-5);
+}
+
+TEST(StreamSimple, ShouldEmitFloat_WhenDoublePrecisionFloatGiven)
+{
+	/* pi in double precision: 0xfb 0x400921fb54442d18 */
+	uint8_t msg[] = { 0xfb, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_FLOAT, rec.events[0].type);
+	DOUBLES_EQUAL(3.14159265358979, rec.events[0].flt_val, 1e-10);
+}
+
+/* ---------- TEST_GROUP: Arrays ---------- */
+
+TEST_GROUP(StreamArray)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamArray, ShouldEmitStartEnd_WhenEmptyArrayGiven)
+{
+	uint8_t msg[] = { 0x80 }; /* [] */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGLONGS_EQUAL(0ll, rec.events[0].container_size);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[1].type);
+	LONGS_EQUAL(0, rec.events[1].depth);
+}
+
+TEST(StreamArray, ShouldEmitItemsWithCorrectDepth_WhenDefiniteArrayGiven)
+{
+	uint8_t msg[] = { 0x82, 0x01, 0x02 }; /* [1, 2] */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGLONGS_EQUAL(2ll, rec.events[0].container_size);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	LONGS_EQUAL(1, rec.events[1].depth);
+	LONGLONGS_EQUAL(1ull, rec.events[1].uint_val);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGLONGS_EQUAL(2ull, rec.events[2].uint_val);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+	LONGS_EQUAL(0, rec.events[3].depth);
+}
+
+TEST(StreamArray, ShouldEmitNestedArrayEvents_WhenNestedArrayGiven)
+{
+	/* [[1]] */
+	uint8_t msg[] = { 0x81, 0x81, 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(5, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(0, rec.events[0].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[1].type);
+	LONGS_EQUAL(1, rec.events[1].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGS_EQUAL(2, rec.events[2].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+	LONGS_EQUAL(1, rec.events[3].depth);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[4].type);
+	LONGS_EQUAL(0, rec.events[4].depth);
+}
+
+TEST(StreamArray, ShouldEmitIndefiniteArray_WhenIndefArrayGiven)
+{
+	/* [_ 1, 2] = 0x9f 0x01 0x02 0xff */
+	uint8_t msg[] = { 0x9f, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].container_size);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+}
+
+TEST(StreamArray, ShouldEmitEvents_WhenArrayFedByteByByte)
+{
+	uint8_t msg[] = { 0x82, 0x01, 0x02 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+}
+
+/* ---------- TEST_GROUP: Maps ---------- */
+
+TEST_GROUP(StreamMap)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamMap, ShouldEmitStartEnd_WhenEmptyMapGiven)
+{
+	uint8_t msg[] = { 0xa0 }; /* {} */
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[1].type);
+}
+
+TEST(StreamMap, ShouldSetIsMapKey_WhenInsideMap)
+{
+	/* {1: 2} = 0xa1 0x01 0x02 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x02 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	CHECK(!rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
+}
+
+TEST(StreamMap, ShouldReportPairCount_WhenDefiniteMapGiven)
+{
+	uint8_t msg[] = { 0xa2, 0x01, 0x02, 0x03, 0x04 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGLONGS_EQUAL(2ll, rec.events[0].container_size);
+}
+
+TEST(StreamMap, ShouldEmitMultiplePairs_WhenMultiPairMapGiven)
+{
+	/* {1:2, 3:4} = 0xa2 0x01 0x02 0x03 0x04 */
+	uint8_t msg[] = { 0xa2, 0x01, 0x02, 0x03, 0x04 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(6, rec.count);
+	CHECK(rec.events[1].is_map_key);  /* key 1 */
+	CHECK(!rec.events[2].is_map_key); /* val 2 */
+	CHECK(rec.events[3].is_map_key);  /* key 3 */
+	CHECK(!rec.events[4].is_map_key); /* val 4 */
+}
+
+TEST(StreamMap, ShouldEmitIndefiniteMap_WhenIndefMapGiven)
+{
+	/* {_ 1:2} = 0xbf 0x01 0x02 0xff */
+	uint8_t msg[] = { 0xbf, 0x01, 0x02, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	LONGLONGS_EQUAL(-1ll, rec.events[0].container_size);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[3].type);
+}
+
+TEST(StreamMap, ShouldReturnIllegal_WhenBreakFollowsOnlyMapKey)
+{
+	uint8_t msg[] = { 0xbf, 0x01, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+/* ---------- TEST_GROUP: Tags ---------- */
+
+TEST_GROUP(StreamTag)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamTag, ShouldEmitTagEvent_WhenTaggedItemGiven)
+{
+	/* tag(1)(0) = 0xc1 0x00 */
+	uint8_t msg[] = { 0xc1, 0x00 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	/* TAG event, then UINT event */
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val); /* tag number */
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[1].type);
+	LONGLONGS_EQUAL(0ull, rec.events[1].uint_val);
+}
+
+TEST(StreamTag, ShouldEmitTagBeforeStart_WhenTaggedArrayGiven)
+{
+	/* tag(0)([]) = 0xc0 0x80 */
+	uint8_t msg[] = { 0xc0, 0x80 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	/* TAG then ARRAY_START then ARRAY_END — no tag on END */
+	LONGS_EQUAL(3, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(0ull, rec.events[0].uint_val);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[1].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[2].type);
+}
+
+TEST(StreamTag, ShouldNotEmitTag_WhenNoTagGiven)
+{
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+}
+
+TEST(StreamTag, ShouldEmitTwoTagEvents_WhenNestedTagsGiven)
+{
+	/* tag(1)(tag(2)(0)) = 0xc1 0xc2 0x00 */
+	uint8_t msg[] = { 0xc1, 0xc2, 0x00 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+
+	/* TAG(1), TAG(2), UINT(0) */
+	LONGS_EQUAL(3, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[1].type);
+	LONGLONGS_EQUAL(2ull, rec.events[1].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[2].type);
+	LONGLONGS_EQUAL(0ull, rec.events[2].uint_val);
+}
+
+TEST(StreamTag, ShouldEmitTwoTagsBeforeStart_WhenNestedTagsOnContainerGiven)
+{
+	/* tag(1)(tag(2)([])) = 0xc1 0xc2 0x80 */
+	uint8_t msg[] = { 0xc1, 0xc2, 0x80 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+
+	/* TAG(1), TAG(2), ARRAY_START, ARRAY_END */
+	LONGS_EQUAL(4, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[1].type);
+	LONGLONGS_EQUAL(2ull, rec.events[1].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[2].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END, rec.events[3].type);
+}
+
+TEST(StreamTag, ShouldEmitTagBeforeFirstChunk_WhenTaggedStringGiven)
+{
+	/* tag(1)("hi") = 0xc1 0x62 0x68 0x69 */
+	uint8_t msg[] = { 0xc1, 0x62, 'h', 'i' };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+
+	/* TAG(1), TEXT("hi") */
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[1].type);
+	CHECK(rec.events[1].str_first);
+	CHECK(rec.events[1].str_last);
+}
+
+TEST(StreamTag, ShouldEmitTagBeforeFirstChunkOnly_WhenTaggedStringFedInChunks)
+{
+	/* tag(1)("hello") fed in separate chunks */
+	uint8_t header[] = { 0xc1, 0x65 }; /* tag(1) + 5-byte text header */
+	uint8_t part1[]  = { 'h', 'e', 'l' };
+	uint8_t part2[]  = { 'l', 'o' };
+
+	feed_all(&decoder, header, sizeof(header));
+	feed_all(&decoder, part1, sizeof(part1));
+	feed_all(&decoder, part2, sizeof(part2));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+
+	/* TAG(1), then TEXT chunks — tag appears only once */
+	CHECK(rec.count >= 2);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+
+	/* all remaining events are TEXT */
+	for (int i = 1; i < rec.count; i++) {
+		LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[i].type);
+	}
+	CHECK(rec.events[1].str_first);
+	CHECK(rec.events[rec.count - 1].str_last);
+}
+
+TEST(StreamTag, ShouldEmitTagBeforeEmptyIndefString_WhenTaggedEmptyIndefStringGiven)
+{
+	/* tag(1)(_ ) = 0xc1 0x5f 0xff */
+	uint8_t msg[] = { 0xc1, 0x5f, 0xff };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+
+	/* TAG(1), BYTES(first=true, last=true, len=0) */
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[0].type);
+	LONGLONGS_EQUAL(1ull, rec.events[0].uint_val);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[1].type);
+	LONGS_EQUAL(0, rec.events[1].str_len);
+	CHECK(rec.events[1].str_first);
+	CHECK(rec.events[1].str_last);
+}
+
+TEST(StreamTag, ShouldReturnExcessive_WhenTagCountExceedsMaxPendingTags)
+{
+	/* CBOR_STREAM_MAX_PENDING_TAGS+1 consecutive tags then a scalar */
+	uint8_t msg[CBOR_STREAM_MAX_PENDING_TAGS + 2];
+	/* all tag(0) bytes = 0xc0 */
+	for (size_t i = 0; i <= CBOR_STREAM_MAX_PENDING_TAGS; i++) {
+		msg[i] = 0xc0;
+	}
+	msg[CBOR_STREAM_MAX_PENDING_TAGS + 1] = 0x00; /* uint 0 */
+
+	LONGS_EQUAL(CBOR_EXCESSIVE,
+		cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamTag, ShouldReturnAborted_WhenCallbackReturnsFalseOnTagEvent)
+{
+	/* Abort on the TAG event itself */
+	rec.abort_after_first = true;
+	rec.abort_at = 1; /* abort after first event (the TAG) */
+
+	uint8_t msg[] = { 0xc1, 0x00 };
+	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+
+	/* sticky: finish() returns same error */
+	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_finish(&decoder));
+}
+
+/* ---------- TEST_GROUP: Error Handling ---------- */
+
+TEST_GROUP(StreamError)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamError, ShouldReturnIllegal_WhenStrayBreakGiven)
+{
+	uint8_t msg[] = { 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnIllegal_WhenBreakInsideDefiniteArray)
+{
+	/* [_ (break)] pretending to be definite: 0x81 0xff */
+	uint8_t msg[] = { 0x81, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnIllegal_WhenBreakFollowsPendingTagInIndefiniteArray)
+{
+	uint8_t msg[] = { 0x9f, 0xc0, 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	/* TAG(0) was emitted before the error */
+	LONGS_EQUAL(2, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[0].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TAG, rec.events[1].type);
+}
+
+TEST(StreamError, ShouldReturnIllegal_WhenReservedAdditionalInfoGiven)
+{
+	uint8_t msg[] = { 0x1c }; /* additional_info=28, reserved */
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldStickyError_WhenSubsequentFeedAfterError)
+{
+	uint8_t bad[] = { 0xff };
+	uint8_t good[] = { 0x01 };
+
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, bad, sizeof(bad)));
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, good, sizeof(good)));
+	LONGS_EQUAL(0, rec.count);
+}
+
+TEST(StreamError, ShouldReturnAborted_WhenCallbackReturnsFalse)
+{
+	rec.abort_after_first = true;
+	rec.abort_at = 1;
+
+	uint8_t msg[] = { 0x01, 0x02 };
+	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenFeedCalledWithNullCallback)
+{
+	cbor_stream_init(&decoder, NULL, NULL);
+
+	uint8_t msg[] = { 0x01 };
+	/* feed() rejects NULL callback */
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	/* finish() only inspects state — decoder stayed IDLE, so returns SUCCESS */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenNegativeIntegerExceedsInt64Range)
+{
+	uint8_t msg[] = {
+		0x3b, 0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenStringLengthExceedsInt64Range)
+{
+	uint8_t msg[] = {
+		0x7b, 0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnInvalid_WhenMapLengthOverflowsItemCount)
+{
+	uint8_t msg[] = {
+		0xbb, 0x40, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	};
+
+	LONGS_EQUAL(CBOR_INVALID, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidItem)
+{
+	uint8_t msg[] = { 0x18 }; /* start of uint with 1-byte length, truncated */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledMidPayload)
+{
+	/* 3-byte text string, only header given */
+	uint8_t msg[] = { 0x63 };
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledInsideOpenArray)
+{
+	uint8_t msg[] = { 0x9f, 0x01 }; /* [_ 1, ... */
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnNeedMore_WhenFinishCalledAfterBareTag)
+{
+	uint8_t msg[] = { 0xc0 };
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, sizeof(msg)));
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterCompleteLengthEncodedUint)
+{
+	uint8_t msg[] = { 0x18, 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterCompleteItem)
+{
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnSuccess_WhenFinishCalledAfterMultipleTopLevelItems)
+{
+	uint8_t msg[] = { 0x01, 0x02, 0x03 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(3, rec.count);
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldTreatZeroLengthFeedAsNoOp)
+{
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, NULL, 0));
+
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+TEST(StreamError, ShouldReturnExcessive_WhenNestingExceedsMaxLevel)
+{
+	/* open CBOR_RECURSION_MAX_LEVEL+1 indefinite arrays */
+	uint8_t msg[CBOR_RECURSION_MAX_LEVEL + 1];
+	for (size_t i = 0; i <= CBOR_RECURSION_MAX_LEVEL; i++) {
+		msg[i] = 0x9f; /* indefinite array */
+	}
+	LONGS_EQUAL(CBOR_EXCESSIVE,
+		cbor_stream_feed(&decoder, msg, sizeof(msg)));
+}
+
+TEST(StreamError, ShouldSucceed_WhenNestingAtMaxLevel)
+{
+	/* open exactly CBOR_RECURSION_MAX_LEVEL indefinite arrays, then close all */
+	uint8_t opens[CBOR_RECURSION_MAX_LEVEL];
+	uint8_t closes[CBOR_RECURSION_MAX_LEVEL];
+	for (size_t i = 0; i < CBOR_RECURSION_MAX_LEVEL; i++) {
+		opens[i]  = 0x9f; /* indefinite array */
+		closes[i] = 0xff; /* BREAK */
+	}
+
+	feed_all(&decoder, opens, sizeof(opens));
+	feed_all(&decoder, closes, sizeof(closes));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+}
+
+/* ---------- TEST_GROUP: Reset ---------- */
+
+TEST_GROUP(StreamReset)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamReset, ShouldDecodeAfterReset_WhenPreviouslyErrored)
+{
+	uint8_t bad[] = { 0xff };
+	LONGS_EQUAL(CBOR_ILLEGAL, cbor_stream_feed(&decoder, bad, sizeof(bad)));
+
+	cbor_stream_reset(&decoder);
+	rec.count = 0;
+
+	uint8_t good[] = { 0x05 };
+	feed_all(&decoder, good, sizeof(good));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+	LONGLONGS_EQUAL(5ull, rec.events[0].uint_val);
+}
+
+TEST(StreamReset, ShouldPreserveCallback_WhenResetCalled)
+{
+	cbor_stream_reset(&decoder);
+
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+}
+
+TEST(StreamReset, ShouldClearPendingTags_WhenResetCalledAfterBareTag)
+{
+	/* feed a tag with no following item */
+	uint8_t bare_tag[] = { 0xc1 };
+	LONGS_EQUAL(CBOR_SUCCESS,
+		cbor_stream_feed(&decoder, bare_tag, sizeof(bare_tag)));
+
+	cbor_stream_reset(&decoder);
+	rec.count = 0;
+
+	/* after reset, normal decoding works */
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+}
+
+TEST(StreamReset, ShouldClearIndefStrState_WhenResetCalledMidIndefString)
+{
+	/* start an indefinite byte string, then reset without finishing */
+	uint8_t indef_start[] = { 0x5f };
+	LONGS_EQUAL(CBOR_SUCCESS,
+		cbor_stream_feed(&decoder, indef_start, sizeof(indef_start)));
+
+	cbor_stream_reset(&decoder);
+	rec.count = 0;
+
+	/* after reset, normal decoding works */
+	uint8_t msg[] = { 0x01 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(1, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[0].type);
+}
+
+/* ---------- TEST_GROUP: Chunked feeds ---------- */
+
+TEST_GROUP(StreamChunked)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamChunked, ShouldDecodeCorrectly_WhenMapFedInChunks)
+{
+	/* {1: "hi"} = 0xa1 0x01 0x62 0x68 0x69 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x62, 0x68, 0x69 };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg, 2));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, msg + 2, 3));
+
+	/* MAP_START, key=1 (uint), value="hi" (text), MAP_END */
+	int evt = 0;
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[evt++].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT, rec.events[evt].type);
+	CHECK(rec.events[evt++].is_map_key);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[evt].type);
+	CHECK(!rec.events[evt++].is_map_key);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END, rec.events[evt++].type);
+	LONGS_EQUAL(evt, rec.count);
+}
+
+TEST(StreamChunked, ShouldDecodeNestedMap_WhenComplexMessageGiven)
+{
+	/* {1: [2, 3]} = 0xa1 0x01 0x82 0x02 0x03 */
+	uint8_t msg[] = { 0xa1, 0x01, 0x82, 0x02, 0x03 };
+	feed_byte_by_byte(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(7, rec.count);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START,   rec.events[0].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[1].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[2].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[3].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[4].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END,   rec.events[5].type);
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,     rec.events[6].type);
+
+	LONGS_EQUAL(1, rec.events[2].depth);
+	LONGS_EQUAL(2, rec.events[3].depth);
+}
+
+/* ---------- TEST_GROUP: is_map_key on END events ---------- */
+
+TEST_GROUP(StreamMapKeyEnd)
+{
+	cbor_stream_decoder_t decoder;
+	Recorder              rec;
+
+	void setup()
+	{
+		memset(&rec, 0, sizeof(rec));
+		cbor_stream_init(&decoder, record_cb, &rec);
+	}
+};
+
+TEST(StreamMapKeyEnd, ShouldReportArrayEndAsMapKey_WhenArrayIsMapKey)
+{
+	/*
+	 * {[1]: "v"}
+	 * 0xa1         map(1 pair)
+	 * 0x81 0x01    array(1): uint 1        <- map key
+	 * 0x61 0x76    text "v"                <- map value
+	 *
+	 * Events:
+	 *  [0] MAP_START      is_map_key=false
+	 *  [1] ARRAY_START    is_map_key=true  (array is the key)
+	 *  [2] UINT(1)        is_map_key=false (inside array)
+	 *  [3] ARRAY_END      is_map_key=true  (array was the key)
+	 *  [4] TEXT "v"       is_map_key=false (value)
+	 *  [5] MAP_END        is_map_key=false
+	 */
+	uint8_t msg[] = { 0xa1, 0x81, 0x01, 0x61, 0x76 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+	LONGS_EQUAL(6, rec.count);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START,   rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_START, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,        rec.events[2].type);
+	CHECK(!rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_ARRAY_END,   rec.events[3].type);
+	CHECK(rec.events[3].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT,        rec.events[4].type);
+	CHECK(!rec.events[4].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,     rec.events[5].type);
+}
+
+TEST(StreamMapKeyEnd, ShouldReportNestedMapEndAsMapKey_WhenNestedMapIsMapKey)
+{
+	/*
+	 * {{1:2}: "v"}
+	 * 0xa1               outer map(1 pair)
+	 * 0xa1 0x01 0x02     inner map{1:2}   <- outer map key
+	 * 0x61 0x76          text "v"         <- outer map value
+	 *
+	 * Events:
+	 *  [0] MAP_START (outer)   is_map_key=false
+	 *  [1] MAP_START (inner)   is_map_key=true
+	 *  [2] UINT(1)             is_map_key=true
+	 *  [3] UINT(2)             is_map_key=false
+	 *  [4] MAP_END (inner)     is_map_key=true
+	 *  [5] TEXT "v"            is_map_key=false
+	 *  [6] MAP_END (outer)     is_map_key=false
+	 */
+	uint8_t msg[] = { 0xa1, 0xa1, 0x01, 0x02, 0x61, 0x76 };
+	feed_all(&decoder, msg, sizeof(msg));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_finish(&decoder));
+	LONGS_EQUAL(7, rec.count);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[0].type);
+	CHECK(!rec.events[0].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_START, rec.events[1].type);
+	CHECK(rec.events[1].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,      rec.events[2].type);
+	CHECK(rec.events[2].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_UINT,      rec.events[3].type);
+	CHECK(!rec.events[3].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,   rec.events[4].type);
+	CHECK(rec.events[4].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT,      rec.events[5].type);
+	CHECK(!rec.events[5].is_map_key);
+
+	LONGS_EQUAL(CBOR_STREAM_EVENT_MAP_END,   rec.events[6].type);
+}
+
+/* ---------- TEST_GROUP: Large payloads ---------- */
+
+TEST_GROUP(StreamLargePayload)
+{
+	cbor_stream_decoder_t decoder;
+	ZeroLengthGuard       guard;
+
+	void setup()
+	{
+		memset(&guard, 0, sizeof(guard));
+		cbor_stream_init(&decoder, reject_zero_length_text_cb, &guard);
+	}
+};
+
+TEST(StreamLargePayload, ShouldMakeForwardProgress_WhenTextLengthExceeds32BitRange)
+{
+	uint8_t header[] = {
+		0x7b,
+		0x00, 0x00, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x00,
+	};
+	uint8_t payload1[] = { 'A' };
+	uint8_t payload2[] = { 'B' };
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, header, sizeof(header)));
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload1, sizeof(payload1)));
+
+	LONGS_EQUAL(1, guard.text_events);
+	CHECK(!guard.saw_zero_len);
+	LONGS_EQUAL(1, guard.last_len);
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+
+	LONGS_EQUAL(CBOR_SUCCESS, cbor_stream_feed(&decoder, payload2, sizeof(payload2)));
+	LONGS_EQUAL(2, guard.text_events);
+	CHECK(!guard.saw_zero_len);
+	LONGS_EQUAL(1, guard.last_len);
+	LONGS_EQUAL(CBOR_NEED_MORE, cbor_stream_finish(&decoder));
+}

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -819,7 +819,7 @@ TEST(StreamTag, ShouldReturnAborted_WhenCallbackReturnsFalseOnTagEvent)
 {
 	/* Abort on the TAG event itself */
 	rec.abort_after_first = true;
-	rec.abort_at = 1; /* abort after first event (the TAG) */
+	rec.abort_at = 0; /* zero-based: abort on first event (the TAG) */
 
 	uint8_t msg[] = { 0xc1, 0x00 };
 	LONGS_EQUAL(CBOR_ABORTED, cbor_stream_feed(&decoder, msg, sizeof(msg)));

--- a/tests/src/stream_test.cpp
+++ b/tests/src/stream_test.cpp
@@ -27,6 +27,7 @@ struct RecordedEvent {
 	uint8_t  str_buf[256];
 	size_t   str_len;
 	int64_t  str_total;
+	bool     str_ptr_is_null;
 	bool     str_first;
 	bool     str_last;
 
@@ -94,6 +95,7 @@ static bool record_cb(const cbor_stream_event_t *event,
 	case CBOR_STREAM_EVENT_BYTES:
 	case CBOR_STREAM_EVENT_TEXT:
 		ev.str_total = data->str.total;
+		ev.str_ptr_is_null = (data->str.ptr == NULL);
 		ev.str_first = data->str.first;
 		ev.str_last  = data->str.last;
 		ev.str_len   = data->str.len;
@@ -244,6 +246,7 @@ TEST(StreamString, ShouldEmitEmptyTextString_WhenZeroLengthTextGiven)
 	LONGS_EQUAL(1, rec.count);
 	LONGS_EQUAL(CBOR_STREAM_EVENT_TEXT, rec.events[0].type);
 	LONGS_EQUAL(0, rec.events[0].str_len);
+	CHECK(rec.events[0].str_ptr_is_null);
 	CHECK(rec.events[0].str_first);
 	CHECK(rec.events[0].str_last);
 }
@@ -330,6 +333,7 @@ TEST(StreamIndefString, ShouldEmitSingleBreakChunk_WhenEmptyIndefStringGiven)
 	LONGS_EQUAL(CBOR_STREAM_EVENT_BYTES, rec.events[0].type);
 	LONGS_EQUAL(0, rec.events[0].str_len);
 	LONGLONGS_EQUAL(-1ll, rec.events[0].str_total);
+	CHECK(rec.events[0].str_ptr_is_null);
 	CHECK(rec.events[0].str_first);
 	CHECK(rec.events[0].str_last);
 }
@@ -353,6 +357,7 @@ TEST(StreamIndefString, ShouldEmitSubChunkThenBreak_WhenIndefStringWithDataGiven
 
 	/* BREAK chunk */
 	LONGS_EQUAL(0, rec.events[1].str_len);
+	CHECK(rec.events[1].str_ptr_is_null);
 	CHECK(!rec.events[1].str_first);
 	CHECK(rec.events[1].str_last);
 }
@@ -370,6 +375,7 @@ TEST(StreamIndefString, ShouldEmitTextChunks_WhenIndefTextStringGiven)
 	CHECK(rec.events[0].str_first);
 	CHECK(rec.events[2].str_last);
 	LONGS_EQUAL(0, rec.events[2].str_len); /* BREAK chunk */
+	CHECK(rec.events[2].str_ptr_is_null);
 }
 
 TEST(StreamIndefString, ShouldReturnIllegal_WhenWrongMajorTypeInIndefString)


### PR DESCRIPTION
This pull request introduces a new streaming CBOR decoder to the codebase, allowing CBOR data to be decoded incrementally with minimal memory usage. It also improves buffer overrun handling in the encoder, adds new error codes, and updates build scripts and documentation accordingly. The most important changes are grouped below:

**Streaming Decoder Implementation:**

* Adds a new streaming CBOR decoder with event-driven parsing, supporting chunked input and callbacks for decoded items. This includes the new public API in `include/cbor/stream.h`, the implementation in `src/stream.c`, and build/test integration via `cbor.mk`, `cbor.cmake`, and a new test runner `tests/runners/stream.mk`. [[1]](diffhunk://#diff-f104cd34d59d245d526197163b75d97ea9ab74302d87b499849ac4697eb7146bR1-R214) [[2]](diffhunk://#diff-8cd089ac189821d0545552f1e5dc265d0cdd002d62ce62dc0c74c2a56ba1843cR10) [[3]](diffhunk://#diff-70084a73b9714a96ec29aa007f411ea68a35b93f733726daaf486cb17c594d1bR14) [[4]](diffhunk://#diff-92f09f560be043c39bad5f9291d5b1a59d9aebf73f06a290d7b93f3fa116dc9aR1-R20)
* Documents the streaming decoder usage, events, and error codes in `README.md`.

**Encoder Robustness:**

* Refactors the encoder to use a new `is_overrun()` helper for buffer overrun checks, and adds checks to floating-point encoding routines to ensure no buffer overflow occurs. [[1]](diffhunk://#diff-4606434a65bd04502916f71a2adf2774435ab6aab3a2f2a7a7b04d378d52e326R43-R47) [[2]](diffhunk://#diff-4606434a65bd04502916f71a2adf2774435ab6aab3a2f2a7a7b04d378d52e326L62-R67) [[3]](diffhunk://#diff-4606434a65bd04502916f71a2adf2774435ab6aab3a2f2a7a7b04d378d52e326R192-R206) [[4]](diffhunk://#diff-4606434a65bd04502916f71a2adf2774435ab6aab3a2f2a7a7b04d378d52e326R225-R228)
* Adds unit tests verifying that the encoder returns `CBOR_OVERRUN` when the buffer is too small for half, single, or double-precision floats.

**Error Handling Improvements:**

* Introduces new error codes `CBOR_NEED_MORE` and `CBOR_ABORTED` for stream decoding, and updates error stringification in `src/helper.c` and error enum in `include/cbor/base.h`. [[1]](diffhunk://#diff-a6d74314c8a71726789893ea2f15bcf36c0e4c38e8aea474b0fa01ba786dd984R37-R38) [[2]](diffhunk://#diff-c3dc28221c0c4e7cf67b749196f0163e4816cb1d8bee60dbbe7ed7e0e21f88aeR253-R256)

**Build and Integration:**

* Updates build scripts (`cbor.mk`, `cbor.cmake`) to include the new streaming decoder source file. [[1]](diffhunk://#diff-8cd089ac189821d0545552f1e5dc265d0cdd002d62ce62dc0c74c2a56ba1843cR10) [[2]](diffhunk://#diff-70084a73b9714a96ec29aa007f411ea68a35b93f733726daaf486cb17c594d1bR14)
* Updates the main header `include/cbor/cbor.h` to include the new streaming decoder API.

**Workflow/CI Improvements:**

* Simplifies the GitHub Actions release workflow to use the `gh` CLI for release creation, removing the version extraction and `actions/create-release` step.